### PR TITLE
SPOG experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ out/
 .env
 
 notes.md
+
+.vscode

--- a/script/SPOGDeploy.s.sol
+++ b/script/SPOGDeploy.s.sol
@@ -5,18 +5,18 @@ import {console} from "forge-std/Script.sol";
 import {BaseScript} from "script/shared/Base.s.sol";
 import {SPOG} from "src/factories/SPOGFactory.sol";
 import {SPOGFactory} from "src/factories/SPOGFactory.sol";
-import {GovSPOGFactory} from "src/factories/GovSPOGFactory.sol";
+import {SPOGGovernorFactory} from "src/factories/SPOGGovernorFactory.sol";
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
 import {ISPOGVotes} from "src/interfaces/ISPOGVotes.sol";
 import {SPOGVotes} from "src/tokens/SPOGVotes.sol";
-import {GovSPOG} from "src/core/GovSPOG.sol";
-import {IGovSPOG} from "src/interfaces/IGovSPOG.sol";
+import {SPOGGovernor} from "src/core/SPOGGovernor.sol";
+import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Vault} from "src/periphery/Vault.sol";
 
 contract SPOGDeployScript is BaseScript {
     SPOGFactory public spogFactory;
-    GovSPOGFactory public govSpogFactory;
+    SPOGGovernorFactory public governorFactory;
     SPOG public spog;
     ERC20Mock public cash;
     uint256[2] public taxRange;
@@ -29,8 +29,8 @@ contract SPOGDeployScript is BaseScript {
     uint256 public voteQuorum;
     uint256 public valueQuorum;
     uint256 public tax;
-    GovSPOG public govSPOGVote;
-    GovSPOG public govSPOGValue;
+    SPOGGovernor public voteGovernor;
+    SPOGGovernor public valueGovernor;
     ISPOGVotes public vote;
     ISPOGVotes public value;
     Vault public vault;
@@ -55,32 +55,32 @@ contract SPOGDeployScript is BaseScript {
         vote = new SPOGVotes("SPOGVote", "vote");
         value = new SPOGVotes("SPOGValue", "value");
 
-        govSpogFactory = new GovSPOGFactory();
+        governorFactory = new SPOGGovernorFactory();
 
-        // predict govSPOGVote address
-        bytes memory govSPOGVotebytecode = govSpogFactory.getBytecode(vote, voteQuorum, voteTime, "GovSPOGVote");
-        uint256 govSPOGVoteSalt = createSalt("GovSPOGVote");
-        address govSPOGVoteAddress = govSpogFactory.predictGovSPOGAddress(govSPOGVotebytecode, govSPOGVoteSalt);
+        // predict vote governor address
+        bytes memory voteGovernorBytecode = governorFactory.getBytecode(vote, voteQuorum, voteTime, "VoteGovernor");
+        uint256 voteGovernorSalt = createSalt("VoteGovernor");
+        address voteGovernorAddress = governorFactory.predictSPOGGovernorAddress(voteGovernorBytecode, voteGovernorSalt);
 
-        // predict govSPOGValue address
-        bytes memory govSPOGValueBytecode = govSpogFactory.getBytecode(value, valueQuorum, forkTime, "GovSPOGValue");
-        uint256 govSPOGValueSalt = createSalt("GovSPOGValue");
-        address govSPOGValueAddress = govSpogFactory.predictGovSPOGAddress(govSPOGValueBytecode, govSPOGValueSalt);
+        // predict value governor address
+        bytes memory valueGovernorBytecode = governorFactory.getBytecode(value, valueQuorum, forkTime, "ValueGovernor");
+        uint256 valueGovernorSalt = createSalt("ValueGovernor");
+        address valueGovernorAddress =
+            governorFactory.predictSPOGGovernorAddress(valueGovernorBytecode, valueGovernorSalt);
 
-        vault = new Vault(govSPOGVoteAddress, govSPOGValueAddress);
+        vault = new Vault(voteGovernorAddress, valueGovernorAddress);
 
-        // deploy govSPOGVote and govSPOGValue from factory
-        govSPOGVote = govSpogFactory.deploy(vote, voteQuorum, voteTime, "GovSPOGVote", govSPOGVoteSalt);
-
-        govSPOGValue = govSpogFactory.deploy(value, valueQuorum, forkTime, "GovSPOGValue", govSPOGValueSalt);
+        // deploy vote and value governors from factory
+        voteGovernor = governorFactory.deploy(vote, voteQuorum, voteTime, "VoteGovernor", voteGovernorSalt);
+        valueGovernor = governorFactory.deploy(value, valueQuorum, forkTime, "ValueGovernor", valueGovernorSalt);
 
         // sanity check
-        assert(address(govSPOGVote) == govSPOGVoteAddress); // GovSPOGVote address mismatch
-        assert(address(govSPOGValue) == govSPOGValueAddress); // GovSPOGValue address mismatch
+        assert(address(voteGovernor) == voteGovernorAddress); // SPOG vote governor address mismatch
+        assert(address(valueGovernor) == valueGovernorAddress); // SPOG value governor address mismatch
 
-        // grant minter role to govSPOG
-        IAccessControl(address(vote)).grantRole(vote.MINTER_ROLE(), address(govSPOGVote));
-        IAccessControl(address(value)).grantRole(value.MINTER_ROLE(), address(govSPOGValue));
+        // grant minter role to vote and value governors
+        IAccessControl(address(vote)).grantRole(vote.MINTER_ROLE(), address(voteGovernor));
+        IAccessControl(address(value)).grantRole(value.MINTER_ROLE(), address(valueGovernor));
 
         spogFactory = new SPOGFactory();
 
@@ -94,8 +94,8 @@ contract SPOGDeployScript is BaseScript {
             forkTime,
             voteQuorum,
             valueQuorum,
-            IGovSPOG(address(govSPOGVote)),
-            IGovSPOG(address(govSPOGValue))
+            ISPOGGovernor(address(voteGovernor)),
+            ISPOGGovernor(address(valueGovernor))
         );
 
         address spogAddress = spogFactory.predictSPOGAddress(bytecode, spogCreationSalt);
@@ -114,17 +114,17 @@ contract SPOGDeployScript is BaseScript {
             forkTime,
             voteQuorum,
             valueQuorum,
-            IGovSPOG(address(govSPOGVote)),
-            IGovSPOG(address(govSPOGValue)),
+            ISPOGGovernor(address(voteGovernor)),
+            ISPOGGovernor(address(valueGovernor)),
             spogCreationSalt
         );
 
         console.log("SPOG address: ", address(spog));
         console.log("SPOGFactory address: ", address(spogFactory));
-        console.log("SPOGVote address: ", address(vote));
-        console.log("SPOGValue address: ", address(value));
-        console.log("GovSPOG for $VOTE address : ", address(govSPOGVote));
-        console.log("GovSPOG for $VALUE address : ", address(govSPOGValue));
+        console.log("SPOGVote token address: ", address(vote));
+        console.log("SPOGValue token address: ", address(value));
+        console.log("SPOGGovernor for $VOTE address : ", address(voteGovernor));
+        console.log("SPOGGovernor for $VALUE address : ", address(valueGovernor));
         console.log("Cash address: ", address(cash));
         console.log("Vault address: ", address(vault));
     }

--- a/src/core/SPOGGovernor.sol
+++ b/src/core/SPOGGovernor.sol
@@ -6,9 +6,9 @@ import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFractio
 import {ISPOGVotes} from "src/interfaces/ISPOGVotes.sol";
 import {ISPOG} from "src/interfaces/ISPOG.sol";
 
-/// @title SPOG Governance Contract
+/// @title SPOG Governor Contract
 /// @notice This contract is used to govern the SPOG protocol. It is a modified version of the Governor contract from OpenZeppelin. It uses the GovernorVotesQuorumFraction contract and its inherited contracts to implement quorum and voting power. The goal is to create a modular Governance contract which SPOG can replace if needed.
-contract GovSPOG is GovernorVotesQuorumFraction {
+contract SPOGGovernor is GovernorVotesQuorumFraction {
     ISPOGVotes public immutable votingToken;
     address public spogAddress;
     uint256 private _votingPeriod;
@@ -45,7 +45,7 @@ contract GovSPOG is GovernorVotesQuorumFraction {
     /// @dev sets the spog address. Can only be called once.
     /// @param _spogAddress the address of the spog
     function initSPOGAddress(address _spogAddress) external {
-        require(spogAddress == address(0), "GovSPOG: spogAddress already set");
+        require(spogAddress == address(0), "SPOGGovernor: spogAddress already set");
 
         votingToken.initSPOGAddress(_spogAddress);
         spogAddress = _spogAddress;
@@ -75,14 +75,14 @@ contract GovSPOG is GovernorVotesQuorumFraction {
     /// @dev Update quorum numerator only by SPOG
     /// @param newQuorumNumerator New quorum numerator
     function updateQuorumNumerator(uint256 newQuorumNumerator) external override {
-        require(msg.sender == spogAddress, "GovSPOG: only SPOG can update quorum numerator");
+        require(msg.sender == spogAddress, "SPOGGovernor: only SPOG can update quorum numerator");
         _updateQuorumNumerator(newQuorumNumerator);
     }
 
     /// @dev Update voting time only by SPOG
     /// @param newVotingTime New voting time
     function updateVotingTime(uint256 newVotingTime) external {
-        require(msg.sender == spogAddress, "GovSPOG: only SPOG can update voting time");
+        require(msg.sender == spogAddress, "SPOGGovernor: only SPOG can update voting time");
 
         _votingPeriod = newVotingTime;
         emit VotingPeriodSet(_votingPeriod, newVotingTime);
@@ -97,7 +97,7 @@ contract GovSPOG is GovernorVotesQuorumFraction {
         bytes[] memory calldatas,
         string memory description
     ) public virtual override returns (uint256) {
-        require(msg.sender == spogAddress, "GovSPOG: only SPOG can propose");
+        require(msg.sender == spogAddress, "SPOGGovernor: only SPOG can propose");
 
         updateStartOfNextVotingPeriod();
         return super.propose(targets, values, calldatas, description);
@@ -149,7 +149,7 @@ contract GovSPOG is GovernorVotesQuorumFraction {
     {
         ProposalVote storage proposalVote = _proposalVotes[proposalId];
 
-        require(!proposalVote.hasVoted[account], "GovSPOG: vote already cast");
+        require(!proposalVote.hasVoted[account], "SPOGGovernor: vote already cast");
         proposalVote.hasVoted[account] = true;
 
         uint256 votes = _getVotes(account, proposalSnapshot(proposalId), "");
@@ -165,7 +165,7 @@ contract GovSPOG is GovernorVotesQuorumFraction {
         if (startOfNextVotingPeriod > block.number) {
             return startOfNextVotingPeriod - block.number;
         } else {
-            revert("GovSPOG: StartOfNextVotingPeriod must be updated");
+            revert("SPOGGovernor: StartOfNextVotingPeriod must be updated");
         }
     }
 
@@ -185,6 +185,6 @@ contract GovSPOG is GovernorVotesQuorumFraction {
     }
 
     fallback() external {
-        revert("GovSPOG: non-existent function");
+        revert("SPOGGovernor: non-existent function");
     }
 }

--- a/src/factories/SPOGFactory.sol
+++ b/src/factories/SPOGFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import {SPOG} from "src/core/SPOG.sol";
-import {IGovSPOG} from "src/interfaces/IGovSPOG.sol";
+import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
 
 /// @title SPOGFactory
 /// @notice This contract is used to deploy SPOG contracts
@@ -16,8 +16,8 @@ contract SPOGFactory {
     /// @param _forkTime The duration that $VALUE holders have to choose a fork
     /// @param _voteQuorum The fraction of the current $VOTE supply voting "YES" for actions that require a `VOTE QUORUM`
     /// @param _valueQuorum The fraction of the current $VALUE supply voting "YES" required for actions that require a `VALUE QUORUM`
-    /// @param _govSPOGVote The address of the SPOG governance contract for $VOTE token
-    /// @param _govSPOGValue The address of the SPOG governance contract for $VALUE token
+    /// @param _voteGovernor The address of the SPOG governor contract for $VOTE token
+    /// @param _valueGovernor The address of the SPOG governor contract for $VALUE token
     /// @param _salt The salt used to deploy the SPOG contract
     /// @return the address of the newly deployed contract
     function deploy(
@@ -27,8 +27,8 @@ contract SPOGFactory {
         uint256 _forkTime,
         uint256 _voteQuorum,
         uint256 _valueQuorum,
-        IGovSPOG _govSPOGVote,
-        IGovSPOG _govSPOGValue,
+        ISPOGGovernor _voteGovernor,
+        ISPOGGovernor _valueGovernor,
         uint256 _salt
     ) public returns (SPOG) {
         SPOG spog = new SPOG{salt: bytes32(_salt)}(
@@ -38,8 +38,8 @@ contract SPOGFactory {
             _forkTime,
             _voteQuorum,
             _valueQuorum,
-            _govSPOGVote,
-            _govSPOGValue
+            _voteGovernor,
+            _valueGovernor
         );
 
         emit SPOGDeployed(address(spog), _salt);
@@ -55,15 +55,15 @@ contract SPOGFactory {
         uint256 _forkTime,
         uint256 _voteQuorum,
         uint256 _valueQuorum,
-        IGovSPOG _govSPOGVote,
-        IGovSPOG _govSPOGValue
+        ISPOGGovernor _voteGovernor,
+        ISPOGGovernor _valueGovernor
     ) public pure returns (bytes memory) {
         bytes memory bytecode = type(SPOG).creationCode;
 
         return abi.encodePacked(
             bytecode,
             abi.encode(
-                _initSPOGData, _vault, _voteTime, _forkTime, _voteQuorum, _valueQuorum, _govSPOGVote, _govSPOGValue
+                _initSPOGData, _vault, _voteTime, _forkTime, _voteQuorum, _valueQuorum, _voteGovernor, _valueGovernor
             )
         );
     }

--- a/src/factories/SPOGGovernorFactory.sol
+++ b/src/factories/SPOGGovernorFactory.sol
@@ -1,45 +1,45 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import {GovSPOG} from "src/core/GovSPOG.sol";
+import {SPOGGovernor} from "src/core/SPOGGovernor.sol";
 import {ISPOGVotes} from "src/interfaces/ISPOGVotes.sol";
 
-/// @title GovSPOGFactory
-/// @notice Factory contract for GovSPOG
-contract GovSPOGFactory {
-    event GovSPOGDeployed(address indexed addr, uint256 salt);
+/// @title SPOGGovernorFactory
+/// @notice Factory contract for SPOGGovernor
+contract SPOGGovernorFactory {
+    event SPOGGovernorDeployed(address indexed addr, uint256 salt);
 
-    /// @dev Deploy a new GovSPOG contract
+    /// @dev Deploy a new SPOGGovernor contract
     /// @param votingTokenContract address of the voting token contract
     /// @param quorumNumeratorValue numerator value for quorum
     /// @param votingPeriod_ voting period
-    /// @param name_ name of the GovSPOG contract
+    /// @param name_ name of the SPOGGovernor contract
     /// @param _salt salt for the contract address
-    /// @return govSpog address of the deployed GovSPOG contract
+    /// @return governor address of the deployed SPOGGovernor contract
     function deploy(
         ISPOGVotes votingTokenContract,
         uint256 quorumNumeratorValue,
         uint256 votingPeriod_,
         string memory name_,
         uint256 _salt
-    ) public returns (GovSPOG) {
-        GovSPOG govSpog = new GovSPOG{salt: bytes32(_salt)}(
+    ) public returns (SPOGGovernor) {
+        SPOGGovernor governor = new SPOGGovernor{salt: bytes32(_salt)}(
             votingTokenContract,
             quorumNumeratorValue,
             votingPeriod_,
             name_
         );
 
-        emit GovSPOGDeployed(address(govSpog), _salt);
-        return govSpog;
+        emit SPOGGovernorDeployed(address(governor), _salt);
+        return governor;
     }
 
-    /// @dev get the bytecode of the GovSPOG contract to be deployed
+    /// @dev get the bytecode of the SPOGGovernor contract to be deployed
     /// @param votingTokenContract address of the voting token contract
     /// @param quorumNumeratorValue numerator value for quorum
     /// @param votingPeriod_ voting period
-    /// @param name_ name of the GovSPOG contract
-    /// @return bytecode of the GovSPOG contract
+    /// @param name_ name of the SPOGGovernor contract
+    /// @return bytecode of the SPOGGovernor contract
     function getBytecode(
         ISPOGVotes votingTokenContract,
         uint256 quorumNumeratorValue,
@@ -47,15 +47,15 @@ contract GovSPOGFactory {
         string memory name_
     ) public pure returns (bytes memory) {
         return abi.encodePacked(
-            type(GovSPOG).creationCode, abi.encode(votingTokenContract, quorumNumeratorValue, votingPeriod_, name_)
+            type(SPOGGovernor).creationCode, abi.encode(votingTokenContract, quorumNumeratorValue, votingPeriod_, name_)
         );
     }
 
-    /// @dev Compute the address of the GovSPOG contract to be deployed
-    /// @param bytecode bytecode of the GovSPOG contract
+    /// @dev Compute the address of the SPOGGovernor contract to be deployed
+    /// @param bytecode bytecode of the SPOGGovernor contract
     /// @param _salt salt for the contract address
-    /// @return address of the GovSPOG contract
-    function predictGovSPOGAddress(bytes memory bytecode, uint256 _salt) public view returns (address) {
+    /// @return address of the SPOGGovernor contract
+    function predictSPOGGovernorAddress(bytes memory bytecode, uint256 _salt) public view returns (address) {
         bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), address(this), _salt, keccak256(bytecode)));
 
         // NOTE: cast last 20 bytes of hash to address
@@ -63,6 +63,6 @@ contract GovSPOGFactory {
     }
 
     fallback() external {
-        revert("GovSPOGFactory: non-existent function called");
+        revert("SPOGGovernorFactory: non-existent function called");
     }
 }

--- a/src/interfaces/ISPOGGovernor.sol
+++ b/src/interfaces/ISPOGGovernor.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
 
-interface IGovSPOG {
+interface ISPOGGovernor {
     function spogAddress() external view returns (address);
 
     function initSPOGAddress(address) external;

--- a/src/periphery/Vault.sol
+++ b/src/periphery/Vault.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {IGovSPOG} from "src/interfaces/IGovSPOG.sol";
+import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
 
 /// @title Vault
 /// @notice contract that will hold the SPOG assets. It has rules for transferring ERC20 tokens out of the smart contract.
@@ -28,7 +28,7 @@ contract Vault {
         // TODO: add require that account must implement auction contract interface
 
         uint256 total = IERC20(token).balanceOf(address(this));
-        require(msg.sender == IGovSPOG(govSpogValueAddress).spogAddress(), "Vault: withdraw not allowed");
+        require(msg.sender == ISPOGGovernor(govSpogValueAddress).spogAddress(), "Vault: withdraw not allowed");
         IERC20(token).safeTransfer(account, total);
 
         emit Withdraw(account, token, total);
@@ -40,7 +40,7 @@ contract Vault {
     function withdraw(address token, uint256 amount) public {
         // TODO: create isAllowedToWithdraw function in govSpogVote
         // require(
-        //     IGovSPOG(govSpogVoteAddress).isAllowedToWithdraw(msg.sender),
+        //     ISPOGGovernor(govSpogVoteAddress).isAllowedToWithdraw(msg.sender),
         //     "Vault: withdraw not allowed"
         // );
 

--- a/src/tokens/SPOGVotes.sol
+++ b/src/tokens/SPOGVotes.sol
@@ -8,7 +8,7 @@ import {ISPOGVotes} from "src/interfaces/ISPOGVotes.sol";
 
 import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 
-/// @title SPOGVotes: voting token for the govSPOG
+/// @title SPOGVotes: voting token for the SPOG governor
 contract SPOGVotes is ERC20Votes, ISPOGVotes, AccessControlEnumerable {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     address public spogAddress;

--- a/test/spog/addNewList/addNewList.t.sol
+++ b/test/spog/addNewList/addNewList.t.sol
@@ -6,11 +6,11 @@ import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
 
 contract SPOG_AddNewList is SPOG_Base {
     function test_Revert_WhenAddingNewList_NotCallingFromGovernance() external {
-        vm.expectRevert("SPOG: Only GovSPOGVote");
+        vm.expectRevert("SPOG: Only vote governor");
         spog.addNewList(IList(address(list)));
     }
 
-    function test_Revert_WhenAddNewList_ByGovSPOGValueHolders() external {
+    function test_Revert_WhenAddNewList_BySPOGGovernorValueHolders() external {
         address[] memory targets = new address[](1);
         targets[0] = address(spog);
         uint256[] memory values = new uint256[](1);
@@ -20,41 +20,41 @@ contract SPOG_AddNewList is SPOG_Base {
         string memory description = "Add new list";
 
         (bytes32 hashedDescription, uint256 proposalId) =
-            getProposalIdAndHashedDescription(govSPOGValue, targets, values, calldatas, description);
+            getProposalIdAndHashedDescription(valueGovernor, targets, values, calldatas, description);
 
         // update start of next voting period
-        govSPOGValue.updateStartOfNextVotingPeriod();
+        valueGovernor.updateStartOfNextVotingPeriod();
 
         // vote on proposal
         deployScript.cash().approve(address(spog), deployScript.tax());
-        spog.propose(IGovSPOG(address(govSPOGValue)), targets, values, calldatas, description);
+        spog.propose(ISPOGGovernor(address(valueGovernor)), targets, values, calldatas, description);
 
         // assert that spog has cash balance
         assert(deployScript.cash().balanceOf(address(spog)) == deployScript.tax());
 
         // check proposal is pending. Note voting is not active until voteDelay is reached
         assertTrue(
-            govSPOGValue.state(proposalId) == IGovernor.ProposalState.Pending, "Proposal is not in an pending state"
+            valueGovernor.state(proposalId) == IGovernor.ProposalState.Pending, "Proposal is not in an pending state"
         );
 
         // fast forward to an active voting period
-        vm.roll(block.number + govSPOGValue.votingDelay() + 1);
+        vm.roll(block.number + valueGovernor.votingDelay() + 1);
 
         // proposal should be active now
-        assertTrue(govSPOGValue.state(proposalId) == IGovernor.ProposalState.Active, "Not in active state");
+        assertTrue(valueGovernor.state(proposalId) == IGovernor.ProposalState.Active, "Not in active state");
 
         // cast vote on proposal
         uint8 yesVote = uint8(VoteType.Yes);
-        govSPOGValue.castVote(proposalId, yesVote);
+        valueGovernor.castVote(proposalId, yesVote);
         // fast forward to end of voting period
         vm.roll(block.number + deployScript.voteTime() + 1);
 
         // check proposal is succeeded
-        assertTrue(govSPOGValue.state(proposalId) == IGovernor.ProposalState.Succeeded, "Not in succeeded state");
+        assertTrue(valueGovernor.state(proposalId) == IGovernor.ProposalState.Succeeded, "Not in succeeded state");
 
-        // proposal execution is not allowed by govSPOGValue holders
-        vm.expectRevert("SPOG: Only GovSPOGVote");
-        govSPOGValue.execute(targets, values, calldatas, hashedDescription);
+        // proposal execution is not allowed by valueGovernor holders
+        vm.expectRevert("SPOG: Only vote governor");
+        valueGovernor.execute(targets, values, calldatas, hashedDescription);
 
         assertFalse(spog.isListInMasterList(address(list)), "List must not have been added to SPOG");
     }
@@ -70,44 +70,44 @@ contract SPOG_AddNewList is SPOG_Base {
         string memory description = "Add new list";
 
         (bytes32 hashedDescription, uint256 proposalId) =
-            getProposalIdAndHashedDescription(govSPOGVote, targets, values, calldatas, description);
+            getProposalIdAndHashedDescription(voteGovernor, targets, values, calldatas, description);
 
         // vote on proposal
         deployScript.cash().approve(address(spog), deployScript.tax());
-        spog.propose(IGovSPOG(address(govSPOGVote)), targets, values, calldatas, description);
+        spog.propose(ISPOGGovernor(address(voteGovernor)), targets, values, calldatas, description);
 
         // assert that spog has cash balance
         assert(deployScript.cash().balanceOf(address(spog)) == deployScript.tax());
 
         // check proposal is pending. Note voting is not active until voteDelay is reached
         assertTrue(
-            govSPOGVote.state(proposalId) == IGovernor.ProposalState.Pending, "Proposal is not in an pending state"
+            voteGovernor.state(proposalId) == IGovernor.ProposalState.Pending, "Proposal is not in an pending state"
         );
 
         // fast forward to an active voting period
-        vm.roll(block.number + govSPOGVote.votingDelay() + 1);
+        vm.roll(block.number + voteGovernor.votingDelay() + 1);
 
         // proposal should be active now
-        assertTrue(govSPOGVote.state(proposalId) == IGovernor.ProposalState.Active, "Not in active state");
+        assertTrue(voteGovernor.state(proposalId) == IGovernor.ProposalState.Active, "Not in active state");
 
         // cast vote on proposal
         uint8 yesVote = uint8(VoteType.Yes);
-        govSPOGVote.castVote(proposalId, yesVote);
+        voteGovernor.castVote(proposalId, yesVote);
         // fast forward to end of voting period
         vm.roll(block.number + deployScript.voteTime() + 1);
 
         // check proposal is succeeded
-        assertTrue(govSPOGVote.state(proposalId) == IGovernor.ProposalState.Succeeded, "Not in succeeded state");
+        assertTrue(voteGovernor.state(proposalId) == IGovernor.ProposalState.Succeeded, "Not in succeeded state");
 
         // TODO: do we need to queue for a time lock execution?
         // queue proposal
         // spog.queue(proposalId);
 
         // execute proposal
-        govSPOGVote.execute(targets, values, calldatas, hashedDescription);
+        voteGovernor.execute(targets, values, calldatas, hashedDescription);
 
         // check proposal is executed
-        assertTrue(govSPOGVote.state(proposalId) == IGovernor.ProposalState.Executed, "Proposal not executed");
+        assertTrue(voteGovernor.state(proposalId) == IGovernor.ProposalState.Executed, "Proposal not executed");
 
         // assert that list was created
         address createdList = address(list);

--- a/test/spog/initialState.t.sol
+++ b/test/spog/initialState.t.sol
@@ -11,15 +11,15 @@ contract SPOG_InitialState is SPOG_Base {
         assertEq(address(cash), address(deployScript.cash()), "cash not set correctly");
         assertEq(inflator, deployScript.inflator(), "inflator not set correctly");
         assertEq(reward, deployScript.reward(), "reward not set correctly");
-        assertEq(govSPOGVote.votingPeriod(), deployScript.voteTime(), "voteTime not set correctly");
-        assertEq(govSPOGValue.votingPeriod(), deployScript.forkTime(), "forkTime not set correctly");
+        assertEq(voteGovernor.votingPeriod(), deployScript.voteTime(), "voteTime not set correctly");
+        assertEq(valueGovernor.votingPeriod(), deployScript.forkTime(), "forkTime not set correctly");
         assertEq(inflatorTime, deployScript.inflatorTime(), "inflatorTime not set correctly");
         assertEq(sellTime, deployScript.sellTime(), "sellTime not set correctly");
-        assertEq(govSPOGVote.quorumNumerator(), deployScript.voteQuorum(), "voteQuorum not set correctly");
-        assertEq(govSPOGValue.quorumNumerator(), deployScript.valueQuorum(), "valueQuorum not set correctly");
+        assertEq(voteGovernor.quorumNumerator(), deployScript.voteQuorum(), "voteQuorum not set correctly");
+        assertEq(valueGovernor.quorumNumerator(), deployScript.valueQuorum(), "valueQuorum not set correctly");
         assertEq(tax, deployScript.tax(), "tax not set correctly");
-        assertEq(address(govSPOGVote.votingToken()), address(deployScript.vote()), "vote token not set correctly");
-        assertEq(address(govSPOGValue.votingToken()), address(deployScript.value()), "value token not set correctly");
+        assertEq(address(voteGovernor.votingToken()), address(deployScript.vote()), "vote token not set correctly");
+        assertEq(address(valueGovernor.votingToken()), address(deployScript.value()), "value token not set correctly");
         // test tax range is set correctly
         (uint256 taxRangeMin, uint256 taxRangeMax) = spog.taxRange();
         assertEq(taxRangeMin, deployScript.taxRange(0), "taxRangeMin not set correctly");

--- a/test/spog/removeList/removeList.t.sol
+++ b/test/spog/removeList/removeList.t.sol
@@ -9,11 +9,11 @@ contract SPOG_RemoveList is SPOG_Base {
         addNewListToSpog();
         address listToRemove = address(list);
 
-        vm.expectRevert("SPOG: Only GovSPOGVote");
+        vm.expectRevert("SPOG: Only vote governor");
         spog.removeList(IList(listToRemove));
     }
 
-    function test_Revert_WhenRemoveList_ByGovSPOGValueHolders() external {
+    function test_Revert_WhenRemoveList_BySPOGGovernorValueHolders() external {
         addNewListToSpog();
 
         address listToRemove = address(list);
@@ -28,27 +28,27 @@ contract SPOG_RemoveList is SPOG_Base {
         string memory description = "remove list";
 
         (bytes32 hashedDescription, uint256 proposalId) =
-            getProposalIdAndHashedDescription(govSPOGValue, targets, values, calldatas, description);
+            getProposalIdAndHashedDescription(valueGovernor, targets, values, calldatas, description);
 
         // update start of next voting period
-        govSPOGValue.updateStartOfNextVotingPeriod();
+        valueGovernor.updateStartOfNextVotingPeriod();
 
         // vote on proposal
         deployScript.cash().approve(address(spog), deployScript.tax());
-        spog.propose(IGovSPOG(address(govSPOGValue)), targets, values, calldatas, description);
+        spog.propose(ISPOGGovernor(address(valueGovernor)), targets, values, calldatas, description);
 
         // fast forward to an active voting period
-        vm.roll(block.number + govSPOGValue.votingDelay() + 1);
+        vm.roll(block.number + valueGovernor.votingDelay() + 1);
 
         // cast vote on proposal
         uint8 yesVote = uint8(VoteType.Yes);
-        govSPOGValue.castVote(proposalId, yesVote);
+        valueGovernor.castVote(proposalId, yesVote);
 
         vm.roll(block.number + deployScript.voteTime() + 1);
 
-        // proposal execution is not allowed by govSPOGValue holders
-        vm.expectRevert("SPOG: Only GovSPOGVote");
-        govSPOGValue.execute(targets, values, calldatas, hashedDescription);
+        // proposal execution is not allowed by valueGovernor holders
+        vm.expectRevert("SPOG: Only vote governor");
+        valueGovernor.execute(targets, values, calldatas, hashedDescription);
 
         assertTrue(spog.isListInMasterList(listToRemove), "List must still be in SPOG");
     }
@@ -68,11 +68,11 @@ contract SPOG_RemoveList is SPOG_Base {
         string memory description = "remove list";
 
         (bytes32 hashedDescription, uint256 proposalId) =
-            getProposalIdAndHashedDescription(govSPOGVote, targets, values, calldatas, description);
+            getProposalIdAndHashedDescription(voteGovernor, targets, values, calldatas, description);
 
         // vote on proposal
         deployScript.cash().approve(address(spog), deployScript.tax());
-        spog.propose(IGovSPOG(address(govSPOGVote)), targets, values, calldatas, description);
+        spog.propose(ISPOGGovernor(address(voteGovernor)), targets, values, calldatas, description);
 
         // assert that spog has cash balance
         assertTrue(
@@ -82,29 +82,29 @@ contract SPOG_RemoveList is SPOG_Base {
 
         // check proposal is pending. Note voting is not active until voteDelay is reached
         assertTrue(
-            govSPOGVote.state(proposalId) == IGovernor.ProposalState.Pending, "Proposal is not in an pending state"
+            voteGovernor.state(proposalId) == IGovernor.ProposalState.Pending, "Proposal is not in an pending state"
         );
 
         // fast forward to an active voting period
-        vm.roll(block.number + govSPOGVote.votingDelay() + 1);
+        vm.roll(block.number + voteGovernor.votingDelay() + 1);
 
         // proposal should be active now
-        assertTrue(govSPOGVote.state(proposalId) == IGovernor.ProposalState.Active, "Not in active state");
+        assertTrue(voteGovernor.state(proposalId) == IGovernor.ProposalState.Active, "Not in active state");
 
         // cast vote on proposal
         uint8 yesVote = uint8(VoteType.Yes);
-        govSPOGVote.castVote(proposalId, yesVote);
+        voteGovernor.castVote(proposalId, yesVote);
         // fast forward to end of voting period
         vm.roll(block.number + deployScript.voteTime() + 1);
 
         // check proposal is succeeded
-        assertTrue(govSPOGVote.state(proposalId) == IGovernor.ProposalState.Succeeded, "Not in succeeded state");
+        assertTrue(voteGovernor.state(proposalId) == IGovernor.ProposalState.Succeeded, "Not in succeeded state");
 
         // execute proposal
-        govSPOGVote.execute(targets, values, calldatas, hashedDescription);
+        voteGovernor.execute(targets, values, calldatas, hashedDescription);
 
         // check proposal is executed
-        assertTrue(govSPOGVote.state(proposalId) == IGovernor.ProposalState.Executed, "Proposal not executed");
+        assertTrue(voteGovernor.state(proposalId) == IGovernor.ProposalState.Executed, "Proposal not executed");
 
         // assert that list was removed
         assertTrue(!spog.isListInMasterList(listToRemove), "List was not removed");

--- a/test/vault/Vault.t.sol
+++ b/test/vault/Vault.t.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.17;
 
 import {StdCheats} from "forge-std/StdCheats.sol";
 import {Vault} from "src/periphery/Vault.sol";
-import {IGovSPOG} from "src/interfaces/IGovSPOG.sol";
+import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
 import {BaseTest} from "test/Base.t.sol";
 
-contract MockGovSPOG is StdCheats {
+contract MockSPOGGovernor is StdCheats {
     address public immutable spogAddress;
 
     constructor() {
@@ -22,8 +22,8 @@ contract VaultTest is BaseTest {
     event Withdraw(address indexed account, address token, uint256 amount);
 
     function setUp() public {
-        address govSpogVoteAddress = address(new MockGovSPOG());
-        address govSpogValueAddress = address(new MockGovSPOG());
+        address govSpogVoteAddress = address(new MockSPOGGovernor());
+        address govSpogValueAddress = address(new MockSPOGGovernor());
         vault = new Vault(govSpogVoteAddress, govSpogValueAddress);
 
         // mint tokens to vault
@@ -38,7 +38,7 @@ contract VaultTest is BaseTest {
     }
 
     function test_Withdraw() public {
-        address spogAddress = IGovSPOG(vault.govSpogVoteAddress()).spogAddress();
+        address spogAddress = ISPOGGovernor(vault.govSpogVoteAddress()).spogAddress();
         vm.prank(spogAddress);
 
         expectEmit();


### PR DESCRIPTION
PR looks big and complex, but in reality, it contains 2 simple logic changes + some renaming of contracts:
1. Add require statement to SPOG governor `propose` function, so that only SPOG can call it.

2. Move `initSPOGAddress` call on token from SPOG into the governor, so it's bundled together. 

3.  Renamings of govSPOGValue and govSPOGVote --> valueGovernor, voteGovernor 
and GovSPOG --> SPOGGovernor. Alternatively, we can import  Governor `as OZGovernor` and just use Governor? The goal is to make it easier to read for auditors and devs who are familiar with Governors. open to not renaming as well, I am getting used to govSpogVote by now :) 

Note: I am thinking about introducing errors vs require statements in a separate PR, so the length of strings in require shouldn't matter. I suspect renaming GovSpog into SPOGGovernor could have crossed some limits of 32bytes. 