### PR TITLE
Add code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ out/
 notes.md
 
 .vscode
+
+coverage/
+lcov.info

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 # dapp deps
 update:; forge update
 
+#coverage report
+coverage :; forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage
+
 # Deployment helpers
 deploy-spog-local :; forge script script/SPOGDeploy.s.sol --rpc-url localhost --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --broadcast -v
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ Test a specific test case
 ```bash
  forge test --mt <test-case-name>
 ```
+
+To view test coverage
+
+Note: On Linux, install genhtml. On MacOS, `brew install lcov`
+
+```bash
+ make coverage
+```
+
+You can then view the file coverage/index.html to view the report. This can also be integrated into vs code with various extentions


### PR DESCRIPTION
This adds a command to the makefile to create a code coverage report to quickly view the state of test coverage