### PR TITLE
Organize counting module methods together

### DIFF
--- a/src/core/SPOGGovernor.sol
+++ b/src/core/SPOGGovernor.sol
@@ -176,7 +176,7 @@ contract SPOGGovernor is GovernorVotesQuorumFraction {
         return _votingPeriod;
     }
 
-    // ********** Counting module funtions ********** //
+    // ********** Counting module functions ********** //
 
     /// @dev See {IGovernor-COUNTING_MODE}.
     // solhint-disable-next-line func-name-mixedcase


### PR DESCRIPTION
No changes to the actual code, organizing counting module methods together after /** Counting module */ comment. 