### PR TITLE
Abstract contract SPOGGoverned and example implementation

### DIFF
--- a/src/external/SPOGGoverned.sol
+++ b/src/external/SPOGGoverned.sol
@@ -1,18 +1,31 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity ^0.8.0;
 
 import {IList} from "src/interfaces/IList.sol";
 import {ISPOG} from "src/interfaces/ISPOG.sol";
 
+/**
+ * @title SPOGGoverned
+ * @dev An abstract contract that provides a function for getting a list contract instance.
+ */
 abstract contract SPOGGoverned {
     error InvalidList(address listAddress);
 
     ISPOG public spog;
 
+    /**
+     * @dev Initializes the SPOG contract address.
+     * @param _spog The address of the SPOG contract.
+     */
     constructor(address _spog) {
         spog = ISPOG(_spog);
     }
 
+    /**
+     * @dev Returns the list contract instance for a given address.
+     * @param listAddress The address of the list contract.
+     * @return The list contract instance.
+     */
     function getListByAddress(address listAddress) public view returns (IList) {
         if (!spog.isListInMasterList(listAddress)) {
             revert InvalidList(listAddress);

--- a/src/interfaces/IList.sol
+++ b/src/interfaces/IList.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity ^0.8.0;
 
 interface IList {
     function admin() external view returns (address);

--- a/src/interfaces/ISPOG.sol
+++ b/src/interfaces/ISPOG.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity ^0.8.0;
 
 import {IList} from "src/interfaces/IList.sol";
 

--- a/test/external/SPOGGoverned.t.sol
+++ b/test/external/SPOGGoverned.t.sol
@@ -7,7 +7,7 @@ import {List} from "src/periphery/List.sol";
 import {IList} from "src/interfaces/IList.sol";
 import "forge-std/console.sol";
 
-contract TestContract is SPOGGoverned {
+contract MockGovernedContract is SPOGGoverned {
     address public collateralManagersListAddress;
 
     constructor(address _spog, address _collateralManagers) SPOGGoverned(_spog) {
@@ -99,7 +99,7 @@ contract SPOGGovernedTest is SPOG_Base {
         // execute vote
         spog.execute(targets, values, calldatas, hashedDescription);
 
-        TestContract testGovernedContract = new TestContract(address(spog), address(list));
+        MockGovernedContract testGovernedContract = new MockGovernedContract(address(spog), address(list));
 
         assertTrue(testGovernedContract.collateralManagersList().contains(alice));
 


### PR DESCRIPTION
Added an abstract contract in src/external called SPOGGoverned.sol

This is a contract that can be inherited to create a governed contract implementation.