### PR TITLE
Add list factory

### DIFF
--- a/src/factories/ListFactory.sol
+++ b/src/factories/ListFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
+import {IList} from "src/interfaces/IList.sol";
 import {List} from "src/periphery/List.sol";
 
 /// @title ListFactory
@@ -12,9 +13,9 @@ contract ListFactory {
     /// @dev creates a list with the given name, adds the addresses to it, and sets admin
     function deploy(address _spog, string memory _name, address[] memory addresses, uint256 _salt)
         public
-        returns (List)
+        returns (IList)
     {
-        List list = new List{salt: bytes32(_salt)}(_name);
+        IList list = IList(address(new List{salt: bytes32(_salt)}(_name)));
 
         uint256 i;
         for (i; i < addresses.length;) {

--- a/test/factories/ListFactory.t.sol
+++ b/test/factories/ListFactory.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import {IList} from "src/interfaces/IList.sol";
+import {ListFactory} from "src/factories/ListFactory.sol";
+import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
+
+contract ListFactoryTest is SPOG_Base {
+    function test_listDeployWithFactory() public {
+        ListFactory listFactory = new ListFactory();
+
+        address item1 = createUser("item1");
+
+        address[] memory items = new address[](1);
+        items[0] = item1;
+
+        IList list = listFactory.deploy(address(spog), "List Name", items, 0);
+
+        assertTrue(list.contains(item1), "item1 should be in the list");
+        assertTrue(list.admin() == address(spog), "spog should be the admin");
+    }
+
+    function test_predictAddress() public {
+        ListFactory listFactory = new ListFactory();
+
+        address item1 = createUser("item1");
+
+        address[] memory items = new address[](1);
+        items[0] = item1;
+
+        IList list = listFactory.deploy(address(spog), "List Name", items, 0);
+
+        bytes memory bytecode = listFactory.getBytecode("List Name");
+
+        address listAddress = listFactory.predictListAddress(bytecode, 0);
+
+        assertTrue(listAddress != address(0), "listAddress should not be 0x0");
+        assertTrue(listAddress == address(list), "listAddress should be the same as the list address");
+    }
+}


### PR DESCRIPTION
Adds a list factory that lets you create a list, with multiple addresses, and set admin to spog, all at once.