### PR TITLE
update to 0.8.20 - depends on upstream change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ out/
 
 notes.md
 
-.vscode
-
 coverage/
 lcov.info
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.formatOnSave": true,
+  "[solidity]": {
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  },
+  "solidity.formatter": "forge",
+  "solidity.compileUsingRemoteVersion": "v0.8.20",
+  "solidity.packageDefaultDependenciesContractsDirectory": "src",
+  "solidity.packageDefaultDependenciesDirectory": "lib"
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-solc-version = "0.8.17"
+solc-version = "0.8.20"
 gas_reports_ignore = ["SPOGDeployScript", "ERC20GodMode"]
 
 [rpc_endpoints]

--- a/script/SPOGDeploy.s.sol
+++ b/script/SPOGDeploy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {console} from "forge-std/Script.sol";
 import {BaseScript} from "script/shared/Base.s.sol";

--- a/script/shared/Base.s.sol
+++ b/script/shared/Base.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {Script} from "forge-std/Script.sol";
 

--- a/src/config/ProtocolConfigurator.sol
+++ b/src/config/ProtocolConfigurator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IProtocolConfigurator} from "src/interfaces/IProtocolConfigurator.sol";

--- a/src/core/SPOG.sol
+++ b/src/core/SPOG.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/src/core/SPOGGovernor.sol
+++ b/src/core/SPOGGovernor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";

--- a/src/core/SPOGStorage.sol
+++ b/src/core/SPOGStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
 import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";

--- a/src/factories/ListFactory.sol
+++ b/src/factories/ListFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {IList} from "src/interfaces/IList.sol";
 import {List} from "src/periphery/List.sol";

--- a/src/factories/SPOGFactory.sol
+++ b/src/factories/SPOGFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOG} from "src/core/SPOG.sol";
 import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";

--- a/src/factories/SPOGGovernorFactory.sol
+++ b/src/factories/SPOGGovernorFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOGGovernor} from "src/core/SPOGGovernor.sol";
 import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";

--- a/src/interfaces/IERC20PricelessAuction.sol
+++ b/src/interfaces/IERC20PricelessAuction.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 interface IERC20PricelessAuction {
     event AuctionPurchase(address indexed buyer, uint256 amount, uint256 price);

--- a/src/interfaces/IGovernorVotesQuorumFraction.sol
+++ b/src/interfaces/IGovernorVotesQuorumFraction.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 interface IGovernorVotesQuorumFraction {
     function quorumNumerator() external view returns (uint256);

--- a/src/interfaces/IProtocolConfigurator.sol
+++ b/src/interfaces/IProtocolConfigurator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 interface IProtocolConfigurator {
     event ConfigChange(bytes32 indexed configName, address contractAddress, bytes4 interfaceId);

--- a/src/interfaces/ISPOGGovernor.sol
+++ b/src/interfaces/ISPOGGovernor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";

--- a/src/interfaces/IVault.sol
+++ b/src/interfaces/IVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
 

--- a/src/interfaces/tokens/ISPOGVotes.sol
+++ b/src/interfaces/tokens/ISPOGVotes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/interfaces/tokens/IValueToken.sol
+++ b/src/interfaces/tokens/IValueToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GLP-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
 

--- a/src/interfaces/tokens/IVoteToken.sol
+++ b/src/interfaces/tokens/IVoteToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GLP-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
 

--- a/src/periphery/ERC165CheckerSPOG.sol
+++ b/src/periphery/ERC165CheckerSPOG.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {ISPOG} from "src/interfaces/ISPOG.sol";
 
 /**
  * @title ERC165CheckerSPOG
- * 
+ *
  * Utility to verify whether an address implements ISPOG.
  */
 

--- a/src/periphery/ERC20PricelessAuction.sol
+++ b/src/periphery/ERC20PricelessAuction.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/periphery/List.sol
+++ b/src/periphery/List.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC165CheckerSPOG} from "src/periphery/ERC165CheckerSPOG.sol";
 

--- a/src/periphery/Vault.sol
+++ b/src/periphery/Vault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/tokens/SPOGVotes.sol
+++ b/src/tokens/SPOGVotes.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 

--- a/src/tokens/ValueToken.sol
+++ b/src/tokens/ValueToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GLP-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC20Snapshot} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Snapshot.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/src/tokens/VoteToken.sol
+++ b/src/tokens/VoteToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GLP-3.0
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC20Snapshot} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Snapshot.sol";
 

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import {ERC20GodMode} from "test/mock/ERC20GodMode.sol";

--- a/test/auction/ERC20PricelessAuction.t.sol
+++ b/test/auction/ERC20PricelessAuction.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {StdCheats} from "forge-std/StdCheats.sol";
 import {ERC20PricelessAuction} from "src/periphery/ERC20PricelessAuction.sol";

--- a/test/external/SPOGGoverned.t.sol
+++ b/test/external/SPOGGoverned.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";

--- a/test/factories/ListFactory.t.sol
+++ b/test/factories/ListFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {IList} from "src/interfaces/IList.sol";
 import {ListFactory} from "src/factories/ListFactory.sol";

--- a/test/factories/SPOGFactory.t.sol
+++ b/test/factories/SPOGFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOGFactory} from "src/factories/SPOGFactory.sol";
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";

--- a/test/factories/SPOGGovernorFactory.t.sol
+++ b/test/factories/SPOGGovernorFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOGGovernorFactory} from "src/factories/SPOGGovernorFactory.sol";
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";

--- a/test/governor/ValueGovernor.t.sol
+++ b/test/governor/ValueGovernor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";

--- a/test/governor/VoteGovernor.t.sol
+++ b/test/governor/VoteGovernor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";

--- a/test/list/List.t.sol
+++ b/test/list/List.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {List, NotAdmin} from "src/periphery/List.sol";
 import {BaseTest} from "test/Base.t.sol";

--- a/test/mock/ERC20GodMode.sol
+++ b/test/mock/ERC20GodMode.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
 

--- a/test/shared/SPOG_Base.t.sol
+++ b/test/shared/SPOG_Base.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "forge-std/console.sol";
 import {BaseTest} from "test/Base.t.sol";

--- a/test/spog/addNewList/addNewList.t.sol
+++ b/test/spog/addNewList/addNewList.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";

--- a/test/spog/appendAddressToList/appendAddressToList.t.sol
+++ b/test/spog/appendAddressToList/appendAddressToList.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 

--- a/test/spog/change/changeTaxWithVoteGovernor.t.sol
+++ b/test/spog/change/changeTaxWithVoteGovernor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 

--- a/test/spog/change/changeVarsWithDoubleQuorum.t.sol
+++ b/test/spog/change/changeVarsWithDoubleQuorum.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 import {ERC20GodMode} from "test/mock/ERC20GodMode.sol";

--- a/test/spog/changeConfig/changeConfig.t.sol
+++ b/test/spog/changeConfig/changeConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/test/spog/emergencyRemove/emergencyRemove.t.sol
+++ b/test/spog/emergencyRemove/emergencyRemove.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";

--- a/test/spog/erc165/erc165Checker.t.sol
+++ b/test/spog/erc165/erc165Checker.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {ERC165CheckerSPOG} from "src/periphery/ERC165CheckerSPOG.sol";

--- a/test/spog/initialState.t.sol
+++ b/test/spog/initialState.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";

--- a/test/spog/propose/SPOGGovernance.t.sol
+++ b/test/spog/propose/SPOGGovernance.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {ISPOG} from "src/interfaces/ISPOG.sol";

--- a/test/spog/removeAddressFromList/removeAddressFromList.t.sol
+++ b/test/spog/removeAddressFromList/removeAddressFromList.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 

--- a/test/spog/removeList/removeList.t.sol
+++ b/test/spog/removeList/removeList.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";

--- a/test/spog/reset/reset.t.sol
+++ b/test/spog/reset/reset.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";

--- a/test/spog/sellUnclaimedVoteTokens/sellUnclaimedVoteTokens.t.sol
+++ b/test/spog/sellUnclaimedVoteTokens/sellUnclaimedVoteTokens.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/vault/helper/Vault_IntegratedWithSPOG.t.sol";
 import {ValueToken} from "src/tokens/ValueToken.sol";

--- a/test/tokens/SpogVotes.t.sol
+++ b/test/tokens/SpogVotes.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {SPOGVotes} from "src/tokens/SPOGVotes.sol";

--- a/test/tokens/ValueToken.t.sol
+++ b/test/tokens/ValueToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {ERC20Snapshot} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Snapshot.sol";
 

--- a/test/tokens/VoteToken.t.sol
+++ b/test/tokens/VoteToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {ValueToken} from "src/tokens/ValueToken.sol";

--- a/test/vault/Vault.t.sol
+++ b/test/vault/Vault.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {StdCheats} from "forge-std/StdCheats.sol";
 import {Vault} from "src/periphery/Vault.sol";

--- a/test/vault/helper/Vault_IntegratedWithSPOG.t.sol
+++ b/test/vault/helper/Vault_IntegratedWithSPOG.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/shared/SPOG_Base.t.sol";
 

--- a/test/vault/withdrawRewardsForValueHolders.t.sol
+++ b/test/vault/withdrawRewardsForValueHolders.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/vault/helper/Vault_IntegratedWithSPOG.t.sol";
 

--- a/test/vault/withdrawValueTokenRewards.t.sol
+++ b/test/vault/withdrawValueTokenRewards.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/vault/helper/Vault_IntegratedWithSPOG.t.sol";
 

--- a/test/vault/withdrawVoteTokenRewards.t.sol
+++ b/test/vault/withdrawVoteTokenRewards.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "test/vault/helper/Vault_IntegratedWithSPOG.t.sol";
 


### PR DESCRIPTION
Apparently this depends on an upstream change here: https://github.com/roynalnaruto/solc-builds

Current version there is only 0.8.19. I'll see if I can open a PR there to update it.