### PR TITLE
Generate docs from natspec

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,41 @@
+# This workflow generates documentation for a project using `forge doc` and sets it up for GitHub pages. It will push the
+# documentation onto a special orphan branch to avoid cluttering the source code. This implementation is modified from
+# https://ntamonsec.blogspot.com/2020/06/github-actions-doxygen-documentation.html
+name: Deploy Documentation
+
+# Controls when the action will run.
+on:
+  push:
+    branches: [main]
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  build-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge doc
+        run: |
+          forge --version
+          forge doc
+        id: doc
+
+      - name: Pages Deployment
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/src/
+          enable_jekyll: false
+          allow_empty_commit: false
+          force_orphan: true
+          publish_branch: github-pages

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage/
 lcov.info
 
 .DS_Store
+
+docs/


### PR DESCRIPTION
This generates markdown docs from natspec and pushes to an orphan branch `github-pages` to avoid cluttering the main branch

Github pages for this repo will be enabled for the branch.

Based on https://kylerobots.github.io/tutorials/Automatic_Documentation/

TODO: Verify GitHub page is private after merging this

