### PR TITLE
Use relative paths

### DIFF
--- a/src/config/ProtocolConfigurator.sol
+++ b/src/config/ProtocolConfigurator.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.19;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {IProtocolConfigurator} from "src/interfaces/IProtocolConfigurator.sol";
+import {IProtocolConfigurator} from "../interfaces/IProtocolConfigurator.sol";
 
 /**
  * @title ProtocolConfigurator

--- a/src/core/SPOG.sol
+++ b/src/core/SPOG.sol
@@ -7,19 +7,19 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import {IList} from "src/interfaces/IList.sol";
-import {IVault} from "src/interfaces/IVault.sol";
+import {IList} from "../interfaces/IList.sol";
+import {IVault} from "../interfaces/IVault.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
-import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
-import {ISPOG} from "src/interfaces/ISPOG.sol";
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
+import {ISPOGGovernor} from "../interfaces/ISPOGGovernor.sol";
+import {ISPOG} from "../interfaces/ISPOG.sol";
+import {ISPOGVotes} from "../interfaces/tokens/ISPOGVotes.sol";
 
-import {SPOGStorage} from "src/core/SPOGStorage.sol";
-import {IVoteToken} from "src/interfaces/tokens/IVoteToken.sol";
-import {IValueToken} from "src/interfaces/tokens/IValueToken.sol";
+import {SPOGStorage} from "../core/SPOGStorage.sol";
+import {IVoteToken} from "../interfaces/tokens/IVoteToken.sol";
+import {IValueToken} from "../interfaces/tokens/IValueToken.sol";
 
-import {IProtocolConfigurator} from "src/interfaces/IProtocolConfigurator.sol";
-import {ProtocolConfigurator} from "src/config/ProtocolConfigurator.sol";
+import {IProtocolConfigurator} from "../interfaces/IProtocolConfigurator.sol";
+import {ProtocolConfigurator} from "../config/ProtocolConfigurator.sol";
 
 /// @title SPOG
 /// @dev Contracts for governing lists and managing communal property through token voting.

--- a/src/core/SPOGGovernor.sol
+++ b/src/core/SPOGGovernor.sol
@@ -3,11 +3,11 @@
 pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
-import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
-import {ISPOG} from "src/interfaces/ISPOG.sol";
-import {IVault} from "src/interfaces/IVault.sol";
-import {IGovernorVotesQuorumFraction} from "src/interfaces/IGovernorVotesQuorumFraction.sol";
+import {ISPOGGovernor} from "../interfaces/ISPOGGovernor.sol";
+import {ISPOGVotes} from "../interfaces/tokens/ISPOGVotes.sol";
+import {ISPOG} from "../interfaces/ISPOG.sol";
+import {IVault} from "../interfaces/IVault.sol";
+import {IGovernorVotesQuorumFraction} from "../interfaces/IGovernorVotesQuorumFraction.sol";
 
 /// @title SPOG Governor Contract
 /// @notice This contract is used to govern the SPOG protocol. It is a modified version of the Governor contract from OpenZeppelin. It uses the GovernorVotesQuorumFraction contract and its inherited contracts to implement quorum and voting power. The goal is to create a modular Governance contract which SPOG can replace if needed.

--- a/src/core/SPOGStorage.sol
+++ b/src/core/SPOGStorage.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
+import {ISPOGGovernor} from "../interfaces/ISPOGGovernor.sol";
+import {ISPOGVotes} from "../interfaces/tokens/ISPOGVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ISPOG} from "src/interfaces/ISPOG.sol";
+import {ISPOG} from "../interfaces/ISPOG.sol";
 
 abstract contract SPOGStorage is ISPOG {
     struct SPOGData {

--- a/src/external/SPOGGoverned.sol
+++ b/src/external/SPOGGoverned.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0;
 
-import {IList} from "src/interfaces/IList.sol";
-import {ISPOG} from "src/interfaces/ISPOG.sol";
+import {IList} from "../interfaces/IList.sol";
+import {ISPOG} from "../interfaces/ISPOG.sol";
 
 /**
  * @title SPOGGoverned

--- a/src/factories/ListFactory.sol
+++ b/src/factories/ListFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {IList} from "src/interfaces/IList.sol";
-import {List} from "src/periphery/List.sol";
+import {IList} from "../interfaces/IList.sol";
+import {List} from "../periphery/List.sol";
 
 /// @title ListFactory
 /// @notice This contract is used to deploy List contracts

--- a/src/factories/SPOGFactory.sol
+++ b/src/factories/SPOGFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {SPOG} from "src/core/SPOG.sol";
-import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
+import {SPOG} from "../core/SPOG.sol";
+import {ISPOGGovernor} from "../interfaces/ISPOGGovernor.sol";
 
 /// @title SPOGFactory
 /// @notice This contract is used to deploy SPOG contracts

--- a/src/factories/SPOGGovernorFactory.sol
+++ b/src/factories/SPOGGovernorFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {SPOGGovernor} from "src/core/SPOGGovernor.sol";
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
+import {SPOGGovernor} from "../core/SPOGGovernor.sol";
+import {ISPOGVotes} from "../interfaces/tokens/ISPOGVotes.sol";
 
 /// @title SPOGGovernorFactory
 /// @notice Factory contract for SPOGGovernor

--- a/src/interfaces/ISPOG.sol
+++ b/src/interfaces/ISPOG.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0;
 
-import {IList} from "src/interfaces/IList.sol";
-import {IProtocolConfigurator} from "src/interfaces/IProtocolConfigurator.sol";
+import {IList} from "../interfaces/IList.sol";
+import {IProtocolConfigurator} from "../interfaces/IProtocolConfigurator.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 interface ISPOG is IProtocolConfigurator, IERC165 {

--- a/src/interfaces/ISPOGGovernor.sol
+++ b/src/interfaces/ISPOGGovernor.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
-import {IGovernorVotesQuorumFraction} from "src/interfaces/IGovernorVotesQuorumFraction.sol";
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
+import {IGovernorVotesQuorumFraction} from "../interfaces/IGovernorVotesQuorumFraction.sol";
+import {ISPOGVotes} from "../interfaces/tokens/ISPOGVotes.sol";
 
 abstract contract ISPOGGovernor is IGovernor, IGovernorVotesQuorumFraction {
     // Errors

--- a/src/interfaces/IVault.sol
+++ b/src/interfaces/IVault.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.19;
 
-import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
+import {ISPOGGovernor} from "../interfaces/ISPOGGovernor.sol";
 
 interface IVault {
     event EpochRewardsDeposit(uint256 indexed epoch, address indexed token, uint256 amount);

--- a/src/interfaces/tokens/IValueToken.sol
+++ b/src/interfaces/tokens/IValueToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GLP-3.0
 pragma solidity 0.8.19;
 
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
+import {ISPOGVotes} from "../../interfaces/tokens/ISPOGVotes.sol";
 
 interface IValueToken is ISPOGVotes {
     function snapshot() external returns (uint256);

--- a/src/interfaces/tokens/IVoteToken.sol
+++ b/src/interfaces/tokens/IVoteToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GLP-3.0
 pragma solidity 0.8.19;
 
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
+import {ISPOGVotes} from "../../interfaces/tokens/ISPOGVotes.sol";
 
 interface IVoteToken is ISPOGVotes {
     // Errors

--- a/src/periphery/ERC165CheckerSPOG.sol
+++ b/src/periphery/ERC165CheckerSPOG.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.19;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import {ISPOG} from "src/interfaces/ISPOG.sol";
+import {ISPOG} from "../interfaces/ISPOG.sol";
 
 /**
  * @title ERC165CheckerSPOG

--- a/src/periphery/ERC20PricelessAuction.sol
+++ b/src/periphery/ERC20PricelessAuction.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
-import {IERC20PricelessAuction} from "src/interfaces/IERC20PricelessAuction.sol";
+import {IERC20PricelessAuction} from "../interfaces/IERC20PricelessAuction.sol";
 
 /// @title ERC20PricelessAuction
 /// @notice A contract for conducting a Dutch auction of ERC20 tokens without a price oracle

--- a/src/periphery/List.sol
+++ b/src/periphery/List.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {ERC165CheckerSPOG} from "src/periphery/ERC165CheckerSPOG.sol";
+import {ERC165CheckerSPOG} from "../periphery/ERC165CheckerSPOG.sol";
 
 error NotAdmin();
 

--- a/src/periphery/Vault.sol
+++ b/src/periphery/Vault.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.19;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ISPOGGovernor} from "src/interfaces/ISPOGGovernor.sol";
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
-import {IVault} from "src/interfaces/IVault.sol";
+import {ISPOGGovernor} from "../interfaces/ISPOGGovernor.sol";
+import {ISPOGVotes} from "../interfaces/tokens/ISPOGVotes.sol";
+import {IVault} from "../interfaces/IVault.sol";
 
-import {IERC20PricelessAuction} from "src/interfaces/IERC20PricelessAuction.sol";
+import {IERC20PricelessAuction} from "../interfaces/IERC20PricelessAuction.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
 /// @title Vault

--- a/src/tokens/SPOGVotes.sol
+++ b/src/tokens/SPOGVotes.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
-import {ISPOGVotes} from "src/interfaces/tokens/ISPOGVotes.sol";
+import {ISPOGVotes} from "../interfaces/tokens/ISPOGVotes.sol";
 
 import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 

--- a/src/tokens/ValueToken.sol
+++ b/src/tokens/ValueToken.sol
@@ -7,7 +7,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC20Votes} from "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
 import {SPOGVotes} from "./SPOGVotes.sol";
-import {IValueToken} from "src/interfaces/tokens/IValueToken.sol";
+import {IValueToken} from "../interfaces/tokens/IValueToken.sol";
 
 /// @title ValueToken
 /// @dev Main token of value governance, has a built-in snapshot functionality.

--- a/src/tokens/VoteToken.sol
+++ b/src/tokens/VoteToken.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.19;
 import {ERC20Snapshot} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Snapshot.sol";
 
 import {SPOGVotes} from "./SPOGVotes.sol";
-import {IVoteToken} from "src/interfaces/tokens/IVoteToken.sol";
+import {IVoteToken} from "../interfaces/tokens/IVoteToken.sol";
 
 /// @title VoteToken
 /// @dev Main token of vote governance.


### PR DESCRIPTION
When importing SPOG into another foundry project, the import paths do not work correctly.

Using relative paths fixes the issue.