### PR TITLE
WEB-107: refactor msg.sender

### DIFF
--- a/src/tokens/SPOGVotes.sol
+++ b/src/tokens/SPOGVotes.sol
@@ -20,9 +20,8 @@ contract SPOGVotes is ERC20Votes, ISPOGVotes, AccessControlEnumerable {
     /// @param name The name of the token
     /// @param symbol The symbol of the token
     constructor(string memory name, string memory symbol) ERC20(name, symbol) ERC20Permit(name) {
-        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
-        // TODO: I think we miss it, revisit later ?
-        _setupRole(MINTER_ROLE, _msgSender());
+        // TODO: Who will be the admin of this contract?
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
     /// @dev sets the spog address. Can only be called once.
@@ -46,7 +45,7 @@ contract SPOGVotes is ERC20Votes, ISPOGVotes, AccessControlEnumerable {
      * See {ERC20-_burn}.
      */
     function burn(uint256 amount) public virtual {
-        _burn(_msgSender(), amount);
+        _burn(msg.sender, amount);
     }
 
     /**
@@ -61,7 +60,7 @@ contract SPOGVotes is ERC20Votes, ISPOGVotes, AccessControlEnumerable {
      * `amount`.
      */
     function burnFrom(address account, uint256 amount) public virtual {
-        _spendAllowance(account, _msgSender(), amount);
+        _spendAllowance(account, msg.sender, amount);
         _burn(account, amount);
     }
 }

--- a/test/tokens/SpogVotes.t.sol
+++ b/test/tokens/SpogVotes.t.sol
@@ -3,10 +3,13 @@ pragma solidity 0.8.19;
 
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {SPOGVotes} from "src/tokens/SPOGVotes.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 contract TestSpogVotes is SPOG_Base {
     function test_MintAndBurn() public {
         SPOGVotes spogVotes = new SPOGVotes("SPOGVotes", "SPOGVotes");
+        // grant minter role to this contract
+        IAccessControl(address(spogVotes)).grantRole(spogVotes.MINTER_ROLE(), address(this));
 
         address user = createUser("user");
 

--- a/test/tokens/ValueToken.t.sol
+++ b/test/tokens/ValueToken.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.19;
 
 import {ERC20Snapshot} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Snapshot.sol";
-
 import {SPOG_Base} from "test/shared/SPOG_Base.t.sol";
 import {ValueToken} from "src/tokens/ValueToken.sol";
 import {SPOGVotes} from "src/tokens/SPOGVotes.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 contract ValueTokenTest is SPOG_Base {
     address alice = createUser("alice");
@@ -19,6 +19,9 @@ contract ValueTokenTest is SPOG_Base {
 
         valueToken = new ValueToken("SPOGValue", "value");
         valueToken.initSPOGAddress(address(spog));
+
+        // grant mint role to this contract
+        IAccessControl(address(valueToken)).grantRole(valueToken.MINTER_ROLE(), address(this));
 
         // Alice can interact with blockchain
         vm.deal({account: alice, newBalance: 10 ether});
@@ -46,30 +49,28 @@ contract ValueTokenTest is SPOG_Base {
     }
 
     function test_MintAndBurn() public {
-        ValueToken valToken = new ValueToken("SPOGVotes", "SPOGVotes");
-
         address user = createUser("user");
 
         // test mint
-        valToken.mint(user, 100);
+        valueToken.mint(user, 100);
 
-        assertEq(valToken.balanceOf(user), 100);
+        assertEq(valueToken.balanceOf(user), 100);
 
         // test burn
         vm.prank(user);
-        valToken.burn(50);
+        valueToken.burn(50);
 
-        assertEq(valToken.balanceOf(user), 50);
+        assertEq(valueToken.balanceOf(user), 50);
 
         // test burnFrom
         address user2 = createUser("user2");
 
         vm.prank(user);
-        valToken.approve(user2, 25);
+        valueToken.approve(user2, 25);
 
         vm.prank(user2);
-        valToken.burnFrom(user, 25);
+        valueToken.burnFrom(user, 25);
 
-        assertEq(valToken.balanceOf(user), 25);
+        assertEq(valueToken.balanceOf(user), 25);
     }
 }

--- a/test/tokens/VoteToken.t.sol
+++ b/test/tokens/VoteToken.t.sol
@@ -6,6 +6,7 @@ import {ValueToken} from "src/tokens/ValueToken.sol";
 import {VoteToken} from "src/tokens/VoteToken.sol";
 import {SPOGVotes} from "src/tokens/SPOGVotes.sol";
 import {IVoteToken} from "src/interfaces/tokens/IVoteToken.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 contract VoteTokenTest is SPOG_Base {
     address alice = createUser("alice");
@@ -38,6 +39,8 @@ contract VoteTokenTest is SPOG_Base {
      */
     function initTokens() private {
         valueToken = new ValueToken("SPOGValue", "value");
+        IAccessControl(address(valueToken)).grantRole(valueToken.MINTER_ROLE(), address(this));
+
         valueToken.initSPOGAddress(address(spog));
 
         // Mint initial balances to users


### PR DESCRIPTION
Removed the msgSender() from the SPOG main contracts as they are used under the OZ library for relayer networks. 

https://forum.openzeppelin.com/t/why-use-msgsender-rather-than-msg-sender/4370/4

We save gas by removing the function call.

I also removed the MINTER_ROLE capability for Vote and Value tokens contract deployer.

Now, this needs to set up explicitly in separate transactions.  

