### PR TITLE
Add list name to ListAdded event

### DIFF
--- a/src/core/SPOG.sol
+++ b/src/core/SPOG.sol
@@ -118,7 +118,7 @@ contract SPOG is ProtocolConfigurator, ERC165, ISPOG {
 
         // add the list to the master list
         _masterlist.set(list, inMasterList);
-        emit ListAdded(list);
+        emit ListAdded(list, IList(list).name());
     }
 
     /// @notice Append an address to a list

--- a/src/interfaces/ISPOG.sol
+++ b/src/interfaces/ISPOG.sol
@@ -17,7 +17,7 @@ interface ISPOG is IProtocolConfigurator, IERC165 {
     }
 
     // Events
-    event ListAdded(address indexed list);
+    event ListAdded(address indexed list, string name);
     event AddressAppendedToList(address indexed list, address indexed account);
     event AddressRemovedFromList(address indexed list, address indexed account);
     event EmergencyExecuted(uint8 emergencyType, bytes callData);

--- a/test/spog/addList.t.sol
+++ b/test/spog/addList.t.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.19;
 import "test/shared/SPOG_Base.t.sol";
 
 contract SPOG_AddNewList is SPOG_Base {
+    // Events to test
+    event ListAdded(address indexed list, string name);
+
     function test_Revert_AddNewList_WhenCallerIsNotSPOG() external {
         vm.expectRevert(ISPOG.OnlyGovernor.selector);
         spog.addList(address(list));
@@ -83,6 +86,9 @@ contract SPOG_AddNewList is SPOG_Base {
 
         // check proposal is succeeded
         assertTrue(governor.state(proposalId) == IGovernor.ProposalState.Succeeded, "Not in succeeded state");
+
+        expectEmit();
+        emit ListAdded(address(list), list.name());
 
         // execute proposal
         governor.execute(targets, values, calldatas, hashedDescription);


### PR DESCRIPTION
This allows the UI to display a list of lists by name, with a single getLogs query. O(1)

Without this change, the UI would need to call getLogs, then call List.name() for each list separately.  O(n)