### PR TITLE
proposal event metadata

### DIFF
--- a/src/core/governor/DualGovernor.sol
+++ b/src/core/governor/DualGovernor.sol
@@ -198,7 +198,7 @@ contract DualGovernor is DualGovernorQuorum {
         ProposalType proposalType = _getProposalType(func);
         _proposalTypes[proposalId] = proposalType;
 
-        emit Proposal(nextEpoch, proposalId, proposalType);
+        emit Proposal(nextEpoch, proposalId, proposalType, targets[0], calldatas[0], description);
 
         return proposalId;
     }

--- a/src/interfaces/ISPOGGovernor.sol
+++ b/src/interfaces/ISPOGGovernor.sol
@@ -36,7 +36,14 @@ interface IDualGovernor {
     error VoteValueMismatch();
 
     // Events
-    event Proposal(uint256 indexed epoch, uint256 indexed proposalId, ProposalType indexed proposalType);
+    event Proposal(
+        uint256 indexed epoch,
+        uint256 indexed proposalId,
+        ProposalType indexed proposalType,
+        address target,
+        bytes data,
+        string description
+    );
     event ValueQuorumNumeratorUpdated(uint256 oldValueQuorumNumerator, uint256 newValueQuorumNumerator);
     event VoteQuorumNumeratorUpdated(uint256 oldVoteQuorumNumerator, uint256 newVoteQuorumNumerator);
 


### PR DESCRIPTION
Adding the target, calldata, and description to this event could simplify the dApp significantly.

Currently there is a similar event inherited from Governor called ProposalCreated, but it is not indexed by proposal id. Thus, the app cannot easily query for proposals by id.

Right now the app has to fetch all events (https://github.com/MZero-Labs/spog-frontend/blob/main/lib/api.ts#L368)  and store them locally to render a page url.com/proposal/[id]. This is not scalable when there are a lot of proposals over time.

