### PR TITLE
Refine indices

### DIFF
--- a/src/interfaces/ISPOGGovernor.sol
+++ b/src/interfaces/ISPOGGovernor.sol
@@ -38,7 +38,7 @@ interface IDualGovernor {
     event Proposal(
         uint256 indexed epoch,
         uint256 indexed proposalId,
-        ProposalType proposalType,
+        ProposalType indexed proposalType,
         address target,
         bytes data,
         string description


### PR DESCRIPTION
<strike>
<p>
TODO: currently pondering whether to remove the indices from AddressAddedToList and AddressRemovedFromList. Since there is currently no other way to get the list names than to read through every AddressAddedToList event, then clients have to scan every record anyway to know which lists exist. Can't search by list without knowing which lists exist... But, once you do know that a list exists they do make it possible to filter the logs for that list.
</p>
<p>
Currently leaning towards leaving it as it is, even though the app will probably not use the index, other clients might find it useful. The app can scan all events to get the list names, then cache them locally and just fetch new blocks to avoid rescanning everything... Index by block for fromBlock/toBlock query exists by default.
</p>
</strike>

Yeah, let's just ship it