### PR TITLE
Address annoying todo for weight

### DIFF
--- a/src/core/governor/DualGovernor.sol
+++ b/src/core/governor/DualGovernor.sol
@@ -241,8 +241,8 @@ contract DualGovernor is DualGovernorQuorum {
             }
         }
 
-        // return bigger of two weights - simple solution for single governance proposals
-        uint256 weight = _max(voteWeight, valueWeight);
+        // return sum of two weights - simple solution for single governance proposals
+        uint256 weight = voteWeight + valueWeight;
 
         if (params.length == 0) {
             emit VoteCast(account, proposalId, support, weight, reason);

--- a/src/core/governor/DualGovernorQuorum.sol
+++ b/src/core/governor/DualGovernorQuorum.sol
@@ -180,9 +180,4 @@ abstract contract DualGovernorQuorum is ISPOGGovernor, Governor {
     function _min(uint256 a, uint256 b) internal pure returns (uint256) {
         return a < b ? a : b;
     }
-
-    // TODO: use OZ Math lib for max and min, only if we decide to keep OZ contracts
-    function _max(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? a : b;
-    }
 }


### PR DESCRIPTION
Return `sum(valueWeight, voteWeight)` for proposals. 

Makes a lot of sense for single VOTE governance (most proposals) and a VALUE (RESET) proposal. 

For double governance, return the sum.  