### PR TITLE
Option 1: allow delegation to zero address

### DIFF
--- a/src/ZeroToken.sol
+++ b/src/ZeroToken.sol
@@ -155,7 +155,7 @@ contract ZeroToken is IZeroToken, EpochBasedVoteToken {
                     --epochsIndex_;
                 }
 
-                delegatees_[epochsIndex_] = _getDefaultIfZero(accountSnap_.account, account_);
+                delegatees_[epochsIndex_] = accountSnap_.account;
 
                 if (epochsIndex_ == 0) return delegatees_;
 

--- a/test/EpochBasedInflationaryVoteToken.t.sol
+++ b/test/EpochBasedInflationaryVoteToken.t.sol
@@ -566,4 +566,38 @@ contract EpochBasedInflationaryVoteTokenTests is TestUtils {
         assertEq(_vote.balanceOf(_bob), 0);
         assertEq(_vote.getVotes(_bob), 2_487);
     }
+
+    function test_addressZeroFailure() external {
+        _warpToNextTransferEpoch();
+
+        _vote.mint(_alice, 1_000);
+        _vote.mint(_bob, 900);
+        _vote.mint(_carol, 800);
+
+        assertEq(_vote.getVotes(_alice), 1_000);
+        assertEq(_vote.getVotes(_bob), 900);
+        assertEq(_vote.getVotes(_carol), 800);
+
+        vm.prank(_alice);
+        _vote.delegate(address(0));
+
+        assertEq(_vote.getVotes(_alice), 0);
+        assertEq(_vote.getVotes(address(0)), 1_000);
+
+        vm.prank(_alice);
+        _vote.delegate(_bob);
+
+        assertEq(_vote.getVotes(_alice), 0);
+        assertEq(_vote.getVotes(_bob), 1_900);
+
+        vm.prank(_alice);
+        _vote.transfer(_carol, 400);
+
+        assertEq(_vote.getVotes(_alice), 0);
+        assertEq(_vote.getVotes(_bob), 1_500);
+        assertEq(_vote.getVotes(_carol), 1200);
+
+        assertEq(_vote.balanceOf(_alice), 600);
+        assertEq(_vote.balanceOf(_carol), 1200);
+    }
 }

--- a/test/EpochBasedVoteToken.t.sol
+++ b/test/EpochBasedVoteToken.t.sol
@@ -83,8 +83,8 @@ contract EpochBasedVoteTokenTests is TestUtils {
 
         assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 1), _bob);
         assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 2), _bob);
-        assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 3), _alice);
-        assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 4), _alice);
+        assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 3), address(0));
+        assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 4), address(0));
         assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 5), _carol);
         assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 6), _carol);
         assertEq(_vote.pastDelegates(_alice, currentEpoch_ - 7), _carol);

--- a/test/ZeroToken.t.sol
+++ b/test/ZeroToken.t.sol
@@ -154,8 +154,8 @@ contract ZeroTokenTests is TestUtils {
         assertEq(delegatees_.length, 5);
         assertEq(delegatees_[0], _carol);
         assertEq(delegatees_[1], _carol);
-        assertEq(delegatees_[2], _alice);
-        assertEq(delegatees_[3], _alice);
+        assertEq(delegatees_[2], address(0));
+        assertEq(delegatees_[3], address(0));
         assertEq(delegatees_[4], _bob);
     }
 
@@ -171,7 +171,7 @@ contract ZeroTokenTests is TestUtils {
         address[] memory delegatees_ = _zeroToken.pastDelegates(_alice, currentEpoch_ - 4, currentEpoch_ - 4);
 
         assertEq(delegatees_.length, 1);
-        assertEq(delegatees_[0], _alice);
+        assertEq(delegatees_[0], address(0));
     }
 
     function test_pastDelegates_multi_beforeAllSnaps() external {
@@ -198,7 +198,7 @@ contract ZeroTokenTests is TestUtils {
         address[] memory delegatees_ = _zeroToken.pastDelegates(_alice, currentEpoch_ - 3, currentEpoch_ - 1);
 
         assertEq(delegatees_.length, 3);
-        assertEq(delegatees_[0], _alice);
+        assertEq(delegatees_[0], address(0));
         assertEq(delegatees_[1], _bob);
         assertEq(delegatees_[2], _bob);
     }


### PR DESCRIPTION
If there is no specific delegation, return `delegator` as `delegatee` (default self-delegation). 

In all remaining cases allow delegation to zero address.