### PR TITLE
Flip the order of `mint` and `transferFrom`

### DIFF
--- a/src/PowerToken.sol
+++ b/src/PowerToken.sol
@@ -119,11 +119,11 @@ contract PowerToken is IPowerToken, EpochBasedInflationaryVoteToken {
 
         emit Buy(msg.sender, amount_, cost_ = getCost(amount_));
 
+        _mint(destination_, amount_);
+
         // NOTE: Not calling `distribute` on vault since anyone can do it, anytime, and this contract should not need to
         //       know how the vault works
         if (!ERC20Helper.transferFrom(cashToken(), msg.sender, vault, cost_)) revert TransferFromFailed();
-
-        _mint(destination_, amount_);
     }
 
     /// @inheritdoc IPowerToken


### PR DESCRIPTION
Even though described in report situation is not possible with pre-determined set of tokens, I flipped the order of functions' calls. Unless there are any cons of such decision, it's an easy change.

Also even if reentrancy happens in this use-case it should not lead to double minting or incorrect supply.

[Quantstamp L04, mz08](https://drive.google.com/file/d/1MxRrTFShrS_CcHxECYzUENF8UB8mPgcX/view?usp=drive_link)

