### PR TITLE
feat: quorum, not threshold

### DIFF
--- a/src/EmergencyGovernor.sol
+++ b/src/EmergencyGovernor.sol
@@ -40,15 +40,15 @@ contract EmergencyGovernor is IEmergencyGovernor, ThresholdGovernor {
      * @param  zeroGovernor_     The address of the Zero Governor contract.
      * @param  registrar_        The address of the Registrar contract.
      * @param  standardGovernor_ The address of the StandardGovernor contract.
-     * @param  thresholdRatio_   The initial threshold ratio.
+     * @param  quorumNumerator_  The numerator defining the percentage of yes votes needed for a passed proposal.
      */
     constructor(
         address voteToken_,
         address zeroGovernor_,
         address registrar_,
         address standardGovernor_,
-        uint16 thresholdRatio_
-    ) ThresholdGovernor("EmergencyGovernor", voteToken_, thresholdRatio_) {
+        uint256 quorumNumerator_
+    ) ThresholdGovernor("EmergencyGovernor", voteToken_, quorumNumerator_) {
         if ((zeroGovernor = zeroGovernor_) == address(0)) revert InvalidZeroGovernorAddress();
         if ((registrar = registrar_) == address(0)) revert InvalidRegistrarAddress();
         if ((standardGovernor = standardGovernor_) == address(0)) revert InvalidStandardGovernorAddress();
@@ -57,8 +57,8 @@ contract EmergencyGovernor is IEmergencyGovernor, ThresholdGovernor {
     /* ============ Interactive Functions ============ */
 
     /// @inheritdoc IEmergencyGovernor
-    function setThresholdRatio(uint16 newThresholdRatio_) external onlyZeroGovernor {
-        _setThresholdRatio(newThresholdRatio_);
+    function setQuorumNumerator(uint256 newQuorumNumerator_) external onlyZeroGovernor {
+        _setQuorumNumerator(newQuorumNumerator_);
     }
 
     /* ============ Proposal Functions ============ */

--- a/src/EmergencyGovernorDeployer.sol
+++ b/src/EmergencyGovernorDeployer.sol
@@ -53,7 +53,7 @@ contract EmergencyGovernorDeployer is IEmergencyGovernorDeployer {
     function deploy(
         address powerToken_,
         address standardGovernor_,
-        uint16 thresholdRatio_
+        uint256 quorumNumerator_
     ) external onlyZeroGovernor returns (address) {
         unchecked {
             ++nonce;
@@ -61,7 +61,7 @@ contract EmergencyGovernorDeployer is IEmergencyGovernorDeployer {
 
         return
             lastDeploy = address(
-                new EmergencyGovernor(powerToken_, zeroGovernor, registrar, standardGovernor_, thresholdRatio_)
+                new EmergencyGovernor(powerToken_, zeroGovernor, registrar, standardGovernor_, quorumNumerator_)
             );
     }
 

--- a/src/StandardGovernor.sol
+++ b/src/StandardGovernor.sol
@@ -22,8 +22,8 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
 
     /**
      * @notice The proposal fee info.
-     * @param cashToken The address of the cash token used to pay the fee.
-     * @param fee       The amount of the fee per proposal.
+     * @param  cashToken The address of the cash token used to pay the fee.
+     * @param  fee       The amount of the fee per proposal.
      */
     struct ProposalFeeInfo {
         address cashToken;
@@ -228,6 +228,11 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
 
     /* ============ View/Pure Functions ============ */
 
+    /// @inheritdoc IGovernor
+    function COUNTING_MODE() external pure returns (string memory) {
+        return "support=against,for&quorum=for&success=standard";
+    }
+
     /// @inheritdoc IStandardGovernor
     function getProposal(
         uint256 proposalId_
@@ -240,7 +245,8 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
             ProposalState state_,
             uint256 noVotes_,
             uint256 yesVotes_,
-            address proposer_
+            address proposer_,
+            uint256 quorum_
         )
     {
         Proposal storage proposal_ = _proposals[proposalId_];
@@ -251,6 +257,7 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
         noVotes_ = proposal_.noWeight;
         yesVotes_ = proposal_.yesWeight;
         proposer_ = proposal_.proposer;
+        quorum_ = 1;
     }
 
     /// @inheritdoc IStandardGovernor
@@ -268,11 +275,6 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
 
     /// @inheritdoc IGovernor
     function quorum() external pure returns (uint256) {
-        return 1;
-    }
-
-    /// @inheritdoc IGovernor
-    function quorum(uint256) external pure returns (uint256) {
         return 1;
     }
 
@@ -390,8 +392,7 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
             voteStart: voteStart_,
             executed: false,
             proposer: msg.sender,
-            thresholdRatio: 0,
-            quorumRatio: 0,
+            quorumNumerator: 0,
             noWeight: 0,
             yesWeight: 0
         });

--- a/src/abstract/BatchGovernor.sol
+++ b/src/abstract/BatchGovernor.sol
@@ -20,21 +20,19 @@ abstract contract BatchGovernor is IBatchGovernor, ERC712Extended {
 
     /**
      * @notice Proposal struct for storing all relevant proposal information.
-     * @param  voteStart      The epoch at which voting begins, inclusively.
-     * @param  executed       Whether or not the proposal has been executed.
-     * @param  proposer       The address of the proposer.
-     * @param  thresholdRatio The ratio of yes votes required for a proposal to succeed.
-     * @param  quorumRatio    The ratio of total votes required for a proposal to succeed.
-     * @param  noWeight       The total number of votes against the proposal.
-     * @param  yesWeight      The total number of votes for the proposal.
+     * @param  voteStart       The epoch at which voting begins, inclusively.
+     * @param  executed        Whether or not the proposal has been executed.
+     * @param  proposer        The address of the proposer.
+     * @param  quorumNumerator The numerator used to compute the quorum of yes votes required for a proposal to succeed.
+     * @param  noWeight        The total number of votes against the proposal.
+     * @param  yesWeight       The total number of votes for the proposal.
      */
     struct Proposal {
         // 1st slot
         uint16 voteStart;
         bool executed;
         address proposer;
-        uint16 thresholdRatio;
-        uint16 quorumRatio;
+        uint16 quorumNumerator;
         // 2nd slot
         uint256 noWeight;
         // 3rd slot
@@ -54,9 +52,6 @@ abstract contract BatchGovernor is IBatchGovernor, ERC712Extended {
 
     /// @dev Length constant for calldata with three arguments.
     uint256 internal constant _SELECTOR_PLUS_3_ARGS = 100;
-
-    /// @inheritdoc IBatchGovernor
-    uint256 public constant ONE = 10_000;
 
     // keccak256("Ballot(uint256 proposalId,uint8 support)")
     /// @inheritdoc IGovernor
@@ -334,11 +329,6 @@ abstract contract BatchGovernor is IBatchGovernor, ERC712Extended {
     }
 
     /// @inheritdoc IGovernor
-    function COUNTING_MODE() external pure returns (string memory) {
-        return "support=against,for&quorum=for";
-    }
-
-    /// @inheritdoc IGovernor
     function proposalThreshold() external pure returns (uint256) {
         return 0;
     }
@@ -610,7 +600,7 @@ abstract contract BatchGovernor is IBatchGovernor, ERC712Extended {
     }
 
     /**
-     * @dev    Returns the vote token's total supply at `timepoint`.
+     * @dev    Returns the vote token's total supply at `timepoint_`.
      * @param  timepoint_ The clock value at which to query the vote token's total supply.
      * @return The vote token's total supply at the `timepoint` clock value.
      */

--- a/src/abstract/interfaces/IBatchGovernor.sol
+++ b/src/abstract/interfaces/IBatchGovernor.sol
@@ -109,7 +109,7 @@ interface IBatchGovernor is IGovernor {
 
     /**
      * @notice Allows a signer to cast votes on multiple proposals via an arbitrary signature.
-     * @param voter        The address of the account casting the votes.
+     * @param  voter       The address of the account casting the votes.
      * @param  proposalIds The list of unique proposal IDs being voted on.
      * @param  supportList The list of support type per proposal IDs to cast.
      * @param  signature   An arbitrary signature
@@ -235,7 +235,4 @@ interface IBatchGovernor is IGovernor {
 
     /// @notice Returns the EIP712 typehash used in the encoding of the digest for `castVotesWithReasonBySig` function.
     function BALLOTS_WITH_REASON_TYPEHASH() external pure returns (bytes32);
-
-    /// @notice Returns the value used as 100%, to be used to correctly ascertain the threshold ratio.
-    function ONE() external pure returns (uint256);
 }

--- a/src/abstract/interfaces/IGovernor.sol
+++ b/src/abstract/interfaces/IGovernor.sol
@@ -272,13 +272,6 @@ interface IGovernor is IERC6372, IERC712 {
     function quorum() external view returns (uint256);
 
     /**
-     * @notice Returns the minimum number of eligible (COUNTING_MODE) votes for a proposal to succeed at `timepoint`.
-     * @param  timepoint The point in time, according to the clock mode the contract is operating on.
-     * @return The quorum value at `timepoint`.
-     */
-    function quorum(uint256 timepoint) external view returns (uint256);
-
-    /**
      * @notice Returns the state of a proposal with identifier `proposalId`.
      * @param  proposalId The unique identifier for the proposal.
      * @return The state of the proposal.

--- a/src/abstract/interfaces/IThresholdGovernor.sol
+++ b/src/abstract/interfaces/IThresholdGovernor.sol
@@ -5,40 +5,42 @@ pragma solidity 0.8.23;
 import { IBatchGovernor } from "./IBatchGovernor.sol";
 
 /**
- * @title  Extension for BatchGovernor with a threshold ratio used to determine quorum and yes-threshold requirements.
+ * @title  Extension for BatchGovernor with a quorum ratio used to determine quorum and yes-threshold requirements.
  * @author M^0 Labs
  */
 interface IThresholdGovernor is IBatchGovernor {
     /* ============ Events ============ */
 
     /**
-     * @notice Emitted when the threshold ratio is set.
-     * @param  thresholdRatio The new threshold ratio.
+     * @notice Emitted when the quorum numerator is set.
+     * @param  oldQuorumNumerator The old quorum numerator.
+     * @param  newQuorumNumerator The new quorum numerator.
      */
-    event ThresholdRatioSet(uint16 thresholdRatio);
+    event QuorumNumeratorUpdated(uint256 oldQuorumNumerator, uint256 newQuorumNumerator);
 
     /* ============ Custom Errors ============ */
 
     /**
-     * @notice Revert message when trying to set the threshold ratio above 100% or below 2.71%.
-     * @param  thresholdRatio    The threshold ratio being set.
-     * @param  minThresholdRatio The minimum allowed threshold ratio.
-     * @param  maxThresholdRatio The maximum allowed threshold ratio.
+     * @notice Revert message when trying to set the quorum numerator above 100% or below 2.71%.
+     * @param  quorumNumerator    The quorum numerator being set.
+     * @param  minQuorumNumerator The minimum allowed quorum numerator.
+     * @param  maxQuorumNumerator The maximum allowed quorum numerator.
      */
-    error InvalidThresholdRatio(uint256 thresholdRatio, uint256 minThresholdRatio, uint256 maxThresholdRatio);
+    error InvalidQuorumNumerator(uint256 quorumNumerator, uint256 minQuorumNumerator, uint256 maxQuorumNumerator);
 
     /* ============ View/Pure Functions ============ */
 
     /**
      * @notice Returns all data of a proposal with identifier `proposalId`.
-     * @param  proposalId     The unique identifier for the proposal.
-     * @return voteStart      The first clock value when voting on the proposal is allowed.
-     * @return voteEnd        The last clock value when voting on the proposal is allowed.
-     * @return state          The state of the proposal.
-     * @return noVotes        The amount of votes cast against the proposal.
-     * @return yesVotes       The amount of votes cast for the proposal.
-     * @return proposer       The address of the account that created the proposal.
-     * @return thresholdRatio The threshold ratio to be applied to determine the threshold/quorum for the proposal.
+     * @param  proposalId      The unique identifier for the proposal.
+     * @return voteStart       The first clock value when voting on the proposal is allowed.
+     * @return voteEnd         The last clock value when voting on the proposal is allowed.
+     * @return state           The state of the proposal.
+     * @return noVotes         The amount of votes cast against the proposal.
+     * @return yesVotes        The amount of votes cast for the proposal.
+     * @return proposer        The address of the account that created the proposal.
+     * @return quorum          The threshold/quorum of yes votes required for the proposal to succeed.
+     * @return quorumNumerator The threshold/quorum numerator used to calculate the quorum.
      */
     function getProposal(
         uint256 proposalId
@@ -52,9 +54,20 @@ interface IThresholdGovernor is IBatchGovernor {
             uint256 noVotes,
             uint256 yesVotes,
             address proposer,
-            uint16 thresholdRatio
+            uint256 quorum,
+            uint16 quorumNumerator
         );
 
-    /// @notice Returns the threshold ratio to be applied to determine the threshold/quorum for a proposal.
-    function thresholdRatio() external view returns (uint16);
+    /**
+     * @notice Returns the quorum/threshold of yes votes needed for a specific proposal to succeed.
+     * @param  proposalId The unique identifier for the proposal.
+     * @return The quorum/threshold of yes votes needed for the proposal to succeed.
+     */
+    function proposalQuorum(uint256 proposalId) external view returns (uint256);
+
+    /// @notice Returns the quorum numerator used to determine the threshold/quorum for a proposal.
+    function quorumNumerator() external view returns (uint256);
+
+    /// @notice Returns the quorum denominator used to determine the threshold/quorum for a proposal.
+    function quorumDenominator() external view returns (uint256);
 }

--- a/src/interfaces/IEmergencyGovernor.sol
+++ b/src/interfaces/IEmergencyGovernor.sol
@@ -26,10 +26,10 @@ interface IEmergencyGovernor is IThresholdGovernor {
     /* ============ Interactive Functions ============ */
 
     /**
-     * @notice Sets the threshold ratio to use going forward for newly created proposals.
-     * @param  newThresholdRatio The new threshold ratio.
+     * @notice Sets the quorum numerator to use going forward for newly created proposals.
+     * @param  newQuorumNumerator The new quorum numerator.
      */
-    function setThresholdRatio(uint16 newThresholdRatio) external;
+    function setQuorumNumerator(uint256 newQuorumNumerator) external;
 
     /* ============ Proposal Functions ============ */
 

--- a/src/interfaces/IEmergencyGovernorDeployer.sol
+++ b/src/interfaces/IEmergencyGovernorDeployer.sol
@@ -26,10 +26,10 @@ interface IEmergencyGovernorDeployer is IDeployer {
      * @notice Deploys a new instance of an Emergency Governor.
      * @param  powerToken       The address of some Power Token that will be used by voters.
      * @param  standardGovernor The address of some Standard Governor.
-     * @param  thresholdRatio   The threshold ratio to use for proposals.
+     * @param  quorumNumerator  The quorum numerator to use for proposals.
      * @return The address of the deployed Emergency Governor.
      */
-    function deploy(address powerToken, address standardGovernor, uint16 thresholdRatio) external returns (address);
+    function deploy(address powerToken, address standardGovernor, uint256 quorumNumerator) external returns (address);
 
     /* ============ View/Pure Functions ============ */
 

--- a/src/interfaces/IStandardGovernor.sol
+++ b/src/interfaces/IStandardGovernor.sol
@@ -145,6 +145,7 @@ interface IStandardGovernor is IBatchGovernor {
      * @return noVotes    The amount of votes cast against the proposal.
      * @return yesVotes   The amount of votes cast for the proposal.
      * @return proposer   The address of the account that created the proposal.
+     * @return quorum     The number of votes required to meet quorum.
      */
     function getProposal(
         uint256 proposalId
@@ -157,7 +158,8 @@ interface IStandardGovernor is IBatchGovernor {
             ProposalState state,
             uint256 noVotes,
             uint256 yesVotes,
-            address proposer
+            address proposer,
+            uint256 quorum
         );
 
     /**

--- a/src/interfaces/IZeroGovernor.sol
+++ b/src/interfaces/IZeroGovernor.sol
@@ -90,16 +90,16 @@ interface IZeroGovernor is IThresholdGovernor {
     function setCashToken(address newCashToken, uint256 newProposalFee) external;
 
     /**
-     * @notice One of the valid proposals. Sets the threshold ratio for Emergency Governor proposals.
-     * @param  newThresholdRatio The new threshold ratio.
+     * @notice One of the valid proposals. Sets the quorum numerator for Emergency Governor proposals.
+     * @param  newQuorumNumerator The new quorum numerator.
      */
-    function setEmergencyProposalThresholdRatio(uint16 newThresholdRatio) external;
+    function setEmergencyProposalQuorumNumerator(uint256 newQuorumNumerator) external;
 
     /**
-     * @notice One of the valid proposals. Sets the threshold ratio for this governor's proposals.
-     * @param  newThresholdRatio The new threshold ratio.
+     * @notice One of the valid proposals. Sets the quorum numerator for this governor's proposals.
+     * @param  newQuorumNumerator The new quorum numerator.
      */
-    function setZeroProposalThresholdRatio(uint16 newThresholdRatio) external;
+    function setZeroProposalQuorumNumerator(uint256 newQuorumNumerator) external;
 
     /* ============ View/Pure Functions ============ */
 

--- a/test/BatchGovernor.t.sol
+++ b/test/BatchGovernor.t.sol
@@ -42,8 +42,7 @@ contract BatchGovernorTests is TestUtils {
             voteStart_: currentEpoch_ - 5,
             executed_: false,
             proposer_: address(0),
-            thresholdRatio_: 0,
-            quorumRatio_: 0,
+            quorumNumerator_: 0,
             noWeight_: 0,
             yesWeight_: 0
         });

--- a/test/DistributionVault.t.sol
+++ b/test/DistributionVault.t.sol
@@ -32,7 +32,7 @@ contract DistributionVaultTests is TestUtils {
     }
 
     /* ============ constructor ============ */
-    function test_constructor() external {
+    function test_constructor() external view {
         assertEq(_vault.zeroToken(), address(_baseToken));
         assertEq(_vault.name(), "DistributionVault");
         assertEq(_vault.CLOCK_MODE(), "mode=epoch");
@@ -45,7 +45,7 @@ contract DistributionVaultTests is TestUtils {
     }
 
     /* ============ CLAIM_TYPEHASH ============ */
-    function test_claimTypeHash() external {
+    function test_claimTypeHash() external view {
         assertEq(
             _vault.CLAIM_TYPEHASH(),
             keccak256(
@@ -201,7 +201,7 @@ contract DistributionVaultTests is TestUtils {
         _vault.getClaimable(address(_token1), _accounts[0], startEpoch_, endEpoch_);
     }
 
-    function test_getClaimable_startEpochSameAsEndEpoch() external {
+    function test_getClaimable_startEpochSameAsEndEpoch() external view {
         uint256 startEpoch_ = _currentEpoch() - 1;
         uint256 endEpoch_ = startEpoch_;
         assertEq(_vault.getClaimable(address(_token1), _accounts[0], startEpoch_, endEpoch_), 0);

--- a/test/ERC5805.t.sol
+++ b/test/ERC5805.t.sol
@@ -20,7 +20,7 @@ contract ERC5805Tests is TestUtils {
     }
 
     /* ============ DELEGATION_TYPEHASH ============ */
-    function test_delegateTypehash() external {
+    function test_delegateTypehash() external view {
         assertEq(
             _erc5805.DELEGATION_TYPEHASH(),
             keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)")

--- a/test/EmergencyGovernor.t.sol
+++ b/test/EmergencyGovernor.t.sol
@@ -28,8 +28,8 @@ contract EmergencyGovernorTests is TestUtils {
 
     address internal _account1 = makeAddr("account1");
 
-    uint16 internal _emergencyProposalThresholdRatio = 9_000; // 90%
-    uint16 internal _zeroProposalThresholdRatio = 6_000; // 60%
+    uint256 internal _emergencyProposalQuorumNumerator = 9_000; // 90%
+    uint256 internal _zeroProposalQuorumNumerator = 6_000; // 60%
 
     address[] internal _allowedCashTokens = [_cashToken1, _cashToken2];
 
@@ -76,8 +76,8 @@ contract EmergencyGovernorTests is TestUtils {
             address(_standardGovernorDeployer),
             address(_bootstrapToken),
             1,
-            1,
-            _zeroProposalThresholdRatio,
+            _emergencyProposalQuorumNumerator,
+            _zeroProposalQuorumNumerator,
             _allowedCashTokens
         );
 
@@ -86,7 +86,7 @@ contract EmergencyGovernorTests is TestUtils {
             address(_zeroGovernor),
             address(_registrar),
             address(_standardGovernor),
-            _emergencyProposalThresholdRatio
+            _emergencyProposalQuorumNumerator
         );
 
         _standardGovernorDeployer.setLastDeploy(address(_standardGovernor));
@@ -94,12 +94,13 @@ contract EmergencyGovernorTests is TestUtils {
         _emergencyGovernorDeployer.setLastDeploy(address(_emergencyGovernor));
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_emergencyGovernor.voteToken(), address(_powerToken));
         assertEq(_emergencyGovernor.zeroGovernor(), address(_zeroGovernor));
         assertEq(_emergencyGovernor.registrar(), address(_registrar));
         assertEq(_emergencyGovernor.standardGovernor(), address(_standardGovernor));
-        assertEq(_emergencyGovernor.thresholdRatio(), _emergencyProposalThresholdRatio);
+        assertEq(_emergencyGovernor.quorumDenominator(), 10_000);
+        assertEq(_emergencyGovernor.quorumNumerator(), _emergencyProposalQuorumNumerator);
     }
 
     /* ============ constructor ============ */
@@ -110,7 +111,7 @@ contract EmergencyGovernorTests is TestUtils {
             address(0),
             address(_registrar),
             address(_standardGovernor),
-            _emergencyProposalThresholdRatio
+            _emergencyProposalQuorumNumerator
         );
     }
 
@@ -121,7 +122,7 @@ contract EmergencyGovernorTests is TestUtils {
             address(_zeroGovernor),
             address(0),
             address(_standardGovernor),
-            _emergencyProposalThresholdRatio
+            _emergencyProposalQuorumNumerator
         );
     }
 
@@ -132,22 +133,22 @@ contract EmergencyGovernorTests is TestUtils {
             address(_zeroGovernor),
             address(_registrar),
             address(0),
-            _emergencyProposalThresholdRatio
+            _emergencyProposalQuorumNumerator
         );
     }
 
-    /* ============ setThresholdRatio ============ */
-    function test_setThresholdRatio() external {
+    /* ============ setQuorumNumerator ============ */
+    function test_setQuorumNumerator() external {
         vm.expectEmit();
-        emit IThresholdGovernor.ThresholdRatioSet(8000);
+        emit IThresholdGovernor.QuorumNumeratorUpdated(_emergencyProposalQuorumNumerator, 8000);
 
         vm.prank(address(_zeroGovernor));
-        _emergencyGovernor.setThresholdRatio(8000);
+        _emergencyGovernor.setQuorumNumerator(8000);
     }
 
-    function test_setThresholdRatio_notZeroGovernor() external {
+    function test_setQuorumNumerator_notZeroGovernor() external {
         vm.expectRevert(IEmergencyGovernor.NotZeroGovernor.selector);
-        _emergencyGovernor.setThresholdRatio(_emergencyProposalThresholdRatio);
+        _emergencyGovernor.setQuorumNumerator(_emergencyProposalQuorumNumerator);
     }
 
     /* ============ addToList ============ */

--- a/test/EmergencyGovernorDeployer.t.sol
+++ b/test/EmergencyGovernorDeployer.t.sol
@@ -18,7 +18,7 @@ contract EmergencyGovernorDeployerTests is Test {
         _deployer = new EmergencyGovernorDeployer(_zeroGovernor, _registrar);
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_deployer.registrar(), _registrar);
         assertEq(_deployer.zeroGovernor(), _zeroGovernor);
         assertEq(_deployer.nonce(), 0);

--- a/test/PowerToken.t.sol
+++ b/test/PowerToken.t.sol
@@ -54,7 +54,7 @@ contract PowerTokenTests is TestUtils {
         _powerToken = new PowerTokenHarness(address(_bootstrapToken), _standardGovernor, address(_cashToken), _vault);
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_powerToken.bootstrapToken(), address(_bootstrapToken));
         assertEq(_powerToken.cashToken(), address(_cashToken));
         assertEq(_powerToken.standardGovernor(), _standardGovernor);

--- a/test/PowerTokenDeployer.t.sol
+++ b/test/PowerTokenDeployer.t.sol
@@ -24,7 +24,7 @@ contract DeployerTests is Test {
         _bootstrapToken.setTotalSupply(1);
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_powerTokenDeployer.vault(), _vault);
         assertEq(_powerTokenDeployer.zeroGovernor(), _zeroGovernor);
         assertEq(_powerTokenDeployer.nonce(), 0);

--- a/test/StandardGovernor.t.sol
+++ b/test/StandardGovernor.t.sol
@@ -76,7 +76,7 @@ contract StandardGovernorTests is TestUtils {
         );
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_standardGovernor.emergencyGovernor(), address(_emergencyGovernor));
         assertEq(_standardGovernor.vault(), _vault);
         assertEq(_standardGovernor.zeroGovernor(), _zeroGovernor);
@@ -180,22 +180,22 @@ contract StandardGovernorTests is TestUtils {
     }
 
     /* ============ typeHashes ============ */
-    function test_ballotTypeHash() external {
+    function test_ballotTypeHash() external view {
         assertEq(_standardGovernor.BALLOT_TYPEHASH(), keccak256("Ballot(uint256 proposalId,uint8 support)"));
     }
 
-    function test_ballotWithReasonTypeHash() external {
+    function test_ballotWithReasonTypeHash() external view {
         assertEq(
             _standardGovernor.BALLOT_WITH_REASON_TYPEHASH(),
             keccak256("BallotWithReason(uint256 proposalId,uint8 support,string reason)")
         );
     }
 
-    function test_ballotsTypeHash() external {
+    function test_ballotsTypeHash() external view {
         assertEq(_standardGovernor.BALLOTS_TYPEHASH(), keccak256("Ballots(uint256[] proposalIds,uint8[] supportList)"));
     }
 
-    function test_ballotsWithReasonTypeHash() external {
+    function test_ballotsWithReasonTypeHash() external view {
         assertEq(
             _standardGovernor.BALLOTS_WITH_REASON_TYPEHASH(),
             keccak256("BallotsWithReason(uint256[] proposalIds,uint8[] supportList,string[] reasonList)")
@@ -203,7 +203,7 @@ contract StandardGovernorTests is TestUtils {
     }
 
     /* ============ ballotDigests ============ */
-    function test_getBallotDigest() external {
+    function test_getBallotDigest() external view {
         uint256 proposalId_ = 1;
         uint8 support_ = uint8(IBatchGovernor.VoteType.Yes);
 
@@ -215,7 +215,7 @@ contract StandardGovernorTests is TestUtils {
         );
     }
 
-    function test_proposalIdsHash() external {
+    function test_proposalIdsHash() external pure {
         // NOTE: as mentioned in EIP-712:
         // The array values are encoded as the `keccak256` hash of the concatenated `encodeData` of their contents
         // (i.e. the encoding of `SomeType[5]` is identical to that of a struct containing five members of type `SomeType`).
@@ -236,7 +236,7 @@ contract StandardGovernorTests is TestUtils {
         );
     }
 
-    function test_supportListHash() external {
+    function test_supportListHash() external pure {
         uint8[] memory supportList_ = new uint8[](5);
         supportList_[0] = 1;
         supportList_[1] = 2;
@@ -254,7 +254,7 @@ contract StandardGovernorTests is TestUtils {
         );
     }
 
-    function test_getBallotsDigest() external {
+    function test_getBallotsDigest() external view {
         uint256[] memory proposalIds_ = new uint256[](2);
         proposalIds_[0] = 1;
         proposalIds_[1] = 2;
@@ -277,7 +277,7 @@ contract StandardGovernorTests is TestUtils {
         );
     }
 
-    function test_getBallotWithReasonDigest() external {
+    function test_getBallotWithReasonDigest() external view {
         uint256 proposalId_ = 1;
         uint8 support_ = uint8(IBatchGovernor.VoteType.Yes);
         string memory reason_ = "Yes";
@@ -297,7 +297,7 @@ contract StandardGovernorTests is TestUtils {
         );
     }
 
-    function test_getReasonListHash() external {
+    function test_getReasonListHash() external view {
         string[] memory reasonList1_ = new string[](2);
         reasonList1_[0] = "12";
         reasonList1_[1] = "3";
@@ -319,7 +319,7 @@ contract StandardGovernorTests is TestUtils {
         );
     }
 
-    function test_getBallotsWithReasonDigest() external {
+    function test_getBallotsWithReasonDigest() external view {
         uint256[] memory proposalIds_ = new uint256[](2);
         proposalIds_[0] = 1;
         proposalIds_[1] = 2;
@@ -1274,9 +1274,8 @@ contract StandardGovernorTests is TestUtils {
 
     /* ============ View Functions ============ */
 
-    function test_quorum() external {
+    function test_quorum() external view {
         assertEq(_standardGovernor.quorum(), 1);
-        assertEq(_standardGovernor.quorum(1), 1);
     }
 
     function test_votingDelay() external {
@@ -1287,7 +1286,7 @@ contract StandardGovernorTests is TestUtils {
         assertEq(_standardGovernor.votingDelay(), 1);
     }
 
-    function test_votingPeriod() external {
+    function test_votingPeriod() external view {
         assertEq(_standardGovernor.votingPeriod(), 0);
     }
 

--- a/test/StandardGovernorDeployer.t.sol
+++ b/test/StandardGovernorDeployer.t.sol
@@ -20,7 +20,7 @@ contract StandardGovernorDeployerTests is Test {
         _deployer = new StandardGovernorDeployer(_zeroGovernor, _registrar, _vault, _zeroToken);
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_deployer.registrar(), _registrar);
         assertEq(_deployer.vault(), _vault);
         assertEq(_deployer.zeroGovernor(), _zeroGovernor);

--- a/test/ZeroGovernor.t.sol
+++ b/test/ZeroGovernor.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity 0.8.23;
 
-import { IThresholdGovernor } from "../src/abstract/interfaces/IThresholdGovernor.sol";
 import { IBatchGovernor } from "../src/abstract/interfaces/IBatchGovernor.sol";
-import { IStandardGovernor } from "../src/interfaces/IStandardGovernor.sol";
+import { IGovernor } from "../src/abstract/interfaces/IGovernor.sol";
+import { IThresholdGovernor } from "../src/abstract/interfaces/IThresholdGovernor.sol";
 import { IZeroGovernor } from "../src/interfaces/IZeroGovernor.sol";
 
 import { MockBootstrapToken, MockEmergencyGovernor, MockEmergencyGovernorDeployer } from "./utils/Mocks.sol";
@@ -16,8 +16,8 @@ contract ZeroGovernorTests is TestUtils {
     address internal _cashToken1 = makeAddr("cashToken1");
     address internal _cashToken2 = makeAddr("cashToken2");
 
-    uint16 internal _emergencyProposalThresholdRatio = 9_000; // 90%
-    uint16 internal _zeroProposalThresholdRatio = 6_000; // 60%
+    uint256 internal _emergencyProposalQuorumNumerator = 9_000; // 90%
+    uint256 internal _zeroProposalQuorumNumerator = 6_000; // 60%
 
     address[] internal _allowedCashTokens = [_cashToken1, _cashToken2];
 
@@ -45,7 +45,7 @@ contract ZeroGovernorTests is TestUtils {
         _zeroToken.setTotalSupply(1);
         _powerToken.setTotalSupply(1);
 
-        _emergencyGovernor.setThresholdRatio(1);
+        _emergencyGovernor.setQuorumNumerator(1);
         _emergencyGovernorDeployer.setNextDeploy(address(_emergencyGovernor));
 
         _powerTokenDeployer.setNextDeploy(address(_powerToken));
@@ -64,7 +64,7 @@ contract ZeroGovernorTests is TestUtils {
             address(_bootstrapToken),
             1,
             1,
-            _zeroProposalThresholdRatio,
+            _zeroProposalQuorumNumerator,
             _allowedCashTokens
         );
 
@@ -73,12 +73,13 @@ contract ZeroGovernorTests is TestUtils {
         _emergencyGovernorDeployer.setLastDeploy(address(_emergencyGovernor));
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_zeroGovernor.voteToken(), address(_zeroToken));
         assertEq(_zeroGovernor.emergencyGovernorDeployer(), address(_emergencyGovernorDeployer));
         assertEq(_zeroGovernor.powerTokenDeployer(), address(_powerTokenDeployer));
         assertEq(_zeroGovernor.standardGovernorDeployer(), address(_standardGovernorDeployer));
-        assertEq(_zeroGovernor.thresholdRatio(), _zeroProposalThresholdRatio);
+        assertEq(_zeroGovernor.quorumDenominator(), 10_000);
+        assertEq(_zeroGovernor.quorumNumerator(), _zeroProposalQuorumNumerator);
         assertEq(_zeroGovernor.isAllowedCashToken(_cashToken1), true);
         assertEq(_zeroGovernor.isAllowedCashToken(_cashToken2), true);
         assertEq(_zeroGovernor.emergencyGovernor(), address(_emergencyGovernor));
@@ -96,7 +97,7 @@ contract ZeroGovernorTests is TestUtils {
             address(_bootstrapToken),
             1,
             1,
-            _zeroProposalThresholdRatio,
+            _zeroProposalQuorumNumerator,
             _allowedCashTokens
         );
     }
@@ -111,7 +112,7 @@ contract ZeroGovernorTests is TestUtils {
             address(_bootstrapToken),
             1,
             1,
-            _zeroProposalThresholdRatio,
+            _zeroProposalQuorumNumerator,
             _allowedCashTokens
         );
     }
@@ -126,7 +127,7 @@ contract ZeroGovernorTests is TestUtils {
             address(_bootstrapToken),
             1,
             1,
-            _zeroProposalThresholdRatio,
+            _zeroProposalQuorumNumerator,
             _allowedCashTokens
         );
     }
@@ -141,7 +142,7 @@ contract ZeroGovernorTests is TestUtils {
             address(_bootstrapToken),
             1,
             1,
-            _zeroProposalThresholdRatio,
+            _zeroProposalQuorumNumerator,
             new address[](0)
         );
     }
@@ -156,7 +157,7 @@ contract ZeroGovernorTests is TestUtils {
             address(_bootstrapToken),
             1,
             1,
-            _zeroProposalThresholdRatio,
+            _zeroProposalQuorumNumerator,
             new address[](1)
         );
     }
@@ -165,6 +166,40 @@ contract ZeroGovernorTests is TestUtils {
     function test_getProposal_proposalDoesNotExist() external {
         vm.expectRevert(IBatchGovernor.ProposalDoesNotExist.selector);
         _zeroGovernor.getProposal(0);
+    }
+
+    function test_getProposal() external {
+        _zeroToken.setTotalSupply(1_000_000);
+
+        _zeroGovernor.setProposal({
+            proposalId_: 1,
+            voteStart_: _currentEpoch(),
+            executed_: false,
+            proposer_: address(1),
+            quorumNumerator_: 4_000,
+            noWeight_: 111,
+            yesWeight_: 222
+        });
+
+        (
+            uint48 voteStart_,
+            uint48 voteEnd_,
+            IGovernor.ProposalState state_,
+            uint256 noVotes_,
+            uint256 yesVotes_,
+            address proposer_,
+            uint256 quorum_,
+            uint16 quorumNumerator_
+        ) = _zeroGovernor.getProposal(1);
+
+        assertEq(voteStart_, _currentEpoch());
+        assertEq(voteEnd_, _currentEpoch() + 1);
+        assertEq(uint8(state_), uint8(IGovernor.ProposalState.Active));
+        assertEq(noVotes_, 111);
+        assertEq(yesVotes_, 222);
+        assertEq(proposer_, address(1));
+        assertEq(quorum_, 400_000);
+        assertEq(quorumNumerator_, 4_000);
     }
 
     /* ============ resetToPowerHolders ============ */
@@ -244,37 +279,39 @@ contract ZeroGovernorTests is TestUtils {
         _zeroGovernor.setCashToken(address(0), 1e18);
     }
 
-    /* ============ setEmergencyProposalThresholdRatio ============ */
-    function test_setEmergencyProposalThresholdRatio() external {
-        vm.expectCall(address(_emergencyGovernor), abi.encodeCall(_emergencyGovernor.setThresholdRatio, (100)));
+    /* ============ setEmergencyProposalQuorumNumerator ============ */
+    function test_setEmergencyProposalQuorumNumerator() external {
+        vm.expectCall(address(_emergencyGovernor), abi.encodeCall(_emergencyGovernor.setQuorumNumerator, (100)));
 
         vm.prank(address(_zeroGovernor));
-        _zeroGovernor.setEmergencyProposalThresholdRatio(100);
+        _zeroGovernor.setEmergencyProposalQuorumNumerator(100);
     }
 
-    function test_setEmergencyProposalThresholdRatio_notZeroGovernor() external {
+    function test_setEmergencyProposalQuorumNumerator_notZeroGovernor() external {
         vm.expectRevert(IBatchGovernor.NotSelf.selector);
-        _zeroGovernor.setEmergencyProposalThresholdRatio(_emergencyProposalThresholdRatio);
+        _zeroGovernor.setEmergencyProposalQuorumNumerator(_emergencyProposalQuorumNumerator);
     }
 
-    /* ============ setZeroProposalThresholdRatio ============ */
-    function test_setZeroProposalThresholdRatio_notZeroGovernor() external {
+    /* ============ setZeroProposalQuorumNumerator ============ */
+    function test_setZeroProposalQuorumNumerator_notZeroGovernor() external {
         vm.expectRevert(IBatchGovernor.NotSelf.selector);
-        _zeroGovernor.setZeroProposalThresholdRatio(_zeroProposalThresholdRatio);
+        _zeroGovernor.setZeroProposalQuorumNumerator(_zeroProposalQuorumNumerator);
     }
 
-    function test_setZeroProposalThresholdRatio_invalidThresholdRatioAboveOne() external {
+    function test_setZeroProposalQuorumNumerator_invalidQuorumNumeratorAboveOne() external {
         vm.prank(address(_zeroGovernor));
 
-        vm.expectRevert(abi.encodeWithSelector(IThresholdGovernor.InvalidThresholdRatio.selector, 10_001, 271, 10_000));
-        _zeroGovernor.setZeroProposalThresholdRatio(10_001);
+        vm.expectRevert(
+            abi.encodeWithSelector(IThresholdGovernor.InvalidQuorumNumerator.selector, 10_001, 271, 10_000)
+        );
+        _zeroGovernor.setZeroProposalQuorumNumerator(10_001);
     }
 
-    function test_setZeroProposalThresholdRatio_invalidThresholdRatioBelowMin() external {
+    function test_setZeroProposalQuorumNumerator_invalidQuorumNumeratorBelowMin() external {
         vm.prank(address(_zeroGovernor));
 
-        vm.expectRevert(abi.encodeWithSelector(IThresholdGovernor.InvalidThresholdRatio.selector, 1, 271, 10_000));
-        _zeroGovernor.setZeroProposalThresholdRatio(1);
+        vm.expectRevert(abi.encodeWithSelector(IThresholdGovernor.InvalidQuorumNumerator.selector, 1, 271, 10_000));
+        _zeroGovernor.setZeroProposalQuorumNumerator(1);
     }
 
     /* ============ revertIfInvalidCalldata ============ */
@@ -304,17 +341,20 @@ contract ZeroGovernorTests is TestUtils {
         );
     }
 
-    function test_revertIfInvalidCalldata_setEmergencyProposalThresholdRatio() external {
+    function test_revertIfInvalidCalldata_setEmergencyProposalQuorumNumerator() external {
         vm.expectRevert(IBatchGovernor.InvalidCallData.selector);
         _zeroGovernor.revertIfInvalidCalldata(
-            abi.encodePacked(abi.encodeCall(_zeroGovernor.setEmergencyProposalThresholdRatio, (1000)), "randomCalldata")
+            abi.encodePacked(
+                abi.encodeCall(_zeroGovernor.setEmergencyProposalQuorumNumerator, (1000)),
+                "randomCalldata"
+            )
         );
     }
 
-    function test_revertIfInvalidCalldata_setZeroProposalThresholdRatio() external {
+    function test_revertIfInvalidCalldata_setZeroProposalQuorumNumerator() external {
         vm.expectRevert(IBatchGovernor.InvalidCallData.selector);
         _zeroGovernor.revertIfInvalidCalldata(
-            abi.encodePacked(abi.encodeCall(_zeroGovernor.setZeroProposalThresholdRatio, (1000)), "randomCalldata")
+            abi.encodePacked(abi.encodeCall(_zeroGovernor.setZeroProposalQuorumNumerator, (1000)), "randomCalldata")
         );
     }
 

--- a/test/ZeroToken.t.sol
+++ b/test/ZeroToken.t.sol
@@ -39,7 +39,7 @@ contract ZeroTokenTests is TestUtils {
         _zeroToken = new ZeroTokenHarness(_standardGovernorDeployer, _initialAccounts, _initialAmounts);
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         assertEq(_zeroToken.standardGovernorDeployer(), _standardGovernorDeployer);
 
         for (uint256 index_; index_ < _initialAccounts.length; index_++) {

--- a/test/fuzz/EmergencyGovernorDeployerFuzz.t.sol
+++ b/test/fuzz/EmergencyGovernorDeployerFuzz.t.sol
@@ -8,7 +8,7 @@ import { IEmergencyGovernorDeployer } from "../../src/interfaces/IEmergencyGover
 
 import { EmergencyGovernorDeployer } from "../../src/EmergencyGovernorDeployer.sol";
 
-import { IThresholdGovernor } from "src/abstract/interfaces/IThresholdGovernor.sol";
+import { IThresholdGovernor } from "../../src/abstract/interfaces/IThresholdGovernor.sol";
 
 contract EmergencyGovernorDeployerTests is Test {
     address internal _registrar = makeAddr("registrar");
@@ -20,24 +20,24 @@ contract EmergencyGovernorDeployerTests is Test {
         _deployer = new EmergencyGovernorDeployer(_zeroGovernor, _registrar);
     }
 
-    function testFuzz_deployAddress(uint16 thresholdRatio_) external {
-        uint16 _MIN_THRESHOLD_RATIO = 271;
-        uint256 ONE = 10_000;
+    function testFuzz_deployAddress(uint256 quorumNumerator_) external {
+        uint256 minQuorumNumerator = 271;
+        uint256 quorumDenominator = 10_000;
         address nextDeploy_ = _deployer.nextDeploy();
 
         vm.prank(_zeroGovernor);
-        if (thresholdRatio_ < _MIN_THRESHOLD_RATIO || thresholdRatio_ > ONE) {
+        if (quorumNumerator_ < minQuorumNumerator || quorumNumerator_ > quorumDenominator) {
             vm.expectRevert(
                 abi.encodeWithSelector(
-                    IThresholdGovernor.InvalidThresholdRatio.selector,
-                    thresholdRatio_,
-                    _MIN_THRESHOLD_RATIO,
-                    ONE
+                    IThresholdGovernor.InvalidQuorumNumerator.selector,
+                    quorumNumerator_,
+                    minQuorumNumerator,
+                    quorumDenominator
                 )
             );
-            _deployer.deploy(makeAddr("voteToken"), makeAddr("standardGovernor"), thresholdRatio_);
+            _deployer.deploy(makeAddr("voteToken"), makeAddr("standardGovernor"), quorumNumerator_);
         } else {
-            address deployed_ = _deployer.deploy(makeAddr("voteToken"), makeAddr("standardGovernor"), thresholdRatio_);
+            address deployed_ = _deployer.deploy(makeAddr("voteToken"), makeAddr("standardGovernor"), quorumNumerator_);
             assertEq(deployed_, nextDeploy_);
         }
     }

--- a/test/fuzz/PowerTokenFuzz.t.sol
+++ b/test/fuzz/PowerTokenFuzz.t.sol
@@ -2,8 +2,6 @@
 
 pragma solidity 0.8.23;
 
-import { console2 } from "../../lib/forge-std/src/Test.sol";
-
 import { PureEpochs } from "../../src/libs/PureEpochs.sol";
 
 import { IEpochBasedInflationaryVoteToken } from "../../src/abstract/interfaces/IEpochBasedInflationaryVoteToken.sol";
@@ -89,8 +87,6 @@ contract PowerTokenTests is TestUtils {
 
         uint240 amountToAuction_ = _powerToken.amountToAuction();
         uint240 amount_ = amountToAuction_ > maxAmount_ ? maxAmount_ : amountToAuction_;
-
-        console2.log(amountToAuction_);
 
         if (amount_ < minAmount_) {
             vm.expectRevert(

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -59,7 +59,7 @@ contract IntegrationTests is TestUtils {
         _registrar = IRegistrar(registrar_);
     }
 
-    function test_initialState() external {
+    function test_initialState() external view {
         IPowerToken powerToken_ = IPowerToken(_registrar.powerToken());
         uint256 initialPowerTotalSupply_;
 

--- a/test/integration/emergency-governor/propose/emergencyGovernorPropose.t.sol
+++ b/test/integration/emergency-governor/propose/emergencyGovernorPropose.t.sol
@@ -214,7 +214,7 @@ contract EmergencyGovernorPropose_IntegrationTest is IntegrationBaseSetup {
 
         assertEq(uint256(_emergencyGovernor.state(proposalId_)), 1); // Active immediately
 
-        (, , , uint256 noVotes, uint256 yesVotes, , ) = _emergencyGovernor.getProposal(proposalId_);
+        (, , , uint256 noVotes, uint256 yesVotes, , , ) = _emergencyGovernor.getProposal(proposalId_);
 
         vm.prank(_alice);
         _emergencyGovernor.castVote(proposalId_, yesSupport_);
@@ -222,7 +222,7 @@ contract EmergencyGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_bob);
         _emergencyGovernor.castVote(proposalId_, yesSupport_);
 
-        (, , , noVotes, yesVotes, , ) = _emergencyGovernor.getProposal(proposalId_);
+        (, , , noVotes, yesVotes, , , ) = _emergencyGovernor.getProposal(proposalId_);
 
         assertEq(uint256(_emergencyGovernor.state(proposalId_)), 4);
     }

--- a/test/integration/inflation-rewards/powerInflationZeroRewards.t.sol
+++ b/test/integration/inflation-rewards/powerInflationZeroRewards.t.sol
@@ -2,8 +2,6 @@
 
 pragma solidity 0.8.23;
 
-import { console2 } from "../../../lib/forge-std/src/Test.sol";
-
 import { IntegrationBaseSetup, IBatchGovernor, IGovernor } from "../IntegrationBaseSetup.t.sol";
 
 contract PowerInflationZeroRewards_IntegrationTest is IntegrationBaseSetup {

--- a/test/integration/standard-governor/propose/standardGovernorPropose.t.sol
+++ b/test/integration/standard-governor/propose/standardGovernorPropose.t.sol
@@ -49,19 +49,19 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_dave);
         _standardGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState pendingState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState pendingState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(pendingState_), 0);
         assertEq(uint256(_standardGovernor.state(proposalId_)), 0);
 
         _warpToNextVoteEpoch();
 
-        (, , IGovernor.ProposalState activeState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(activeState_), 1);
         assertEq(uint256(_standardGovernor.state(proposalId_)), 1);
 
         _warpToNextEpoch();
 
-        (, , IGovernor.ProposalState defeatedState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState defeatedState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(defeatedState_), 3);
         assertEq(uint256(_standardGovernor.state(proposalId_)), 3);
     }
@@ -99,12 +99,12 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_dave);
         _standardGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState pendingState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState pendingState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(pendingState_), 0);
 
         _warpToNextVoteEpoch();
 
-        (, , IGovernor.ProposalState activeState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(activeState_), 1);
 
         uint8 yesSupport_ = uint8(IBatchGovernor.VoteType.Yes);
@@ -141,12 +141,12 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
 
         _warpToNextEpoch();
 
-        (, , IGovernor.ProposalState succeededState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState succeededState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(succeededState_), 4);
 
         _warpToNextEpoch();
 
-        (, , IGovernor.ProposalState expiredState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState expiredState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(expiredState_), 6);
 
         uint256 vaultCashBalanceBefore_ = _cashToken1.balanceOf(address(_vault));
@@ -190,12 +190,12 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_dave);
         _standardGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState pendingState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState pendingState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(pendingState_), 0);
 
         _warpToNextVoteEpoch();
 
-        (, , IGovernor.ProposalState activeState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(activeState_), 1);
 
         uint8 yesSupport_ = uint8(IBatchGovernor.VoteType.Yes);
@@ -232,7 +232,7 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
 
         _warpToNextEpoch();
 
-        (, , IGovernor.ProposalState succeededState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState succeededState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(succeededState_), 4);
 
         vm.expectEmit();
@@ -252,7 +252,7 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         assertFalse(_registrar.listContains("MintersList", _dave));
         assertTrue(_registrar.listContains("MintersList", _eve));
 
-        (, , IGovernor.ProposalState executedState_, , , ) = _standardGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState executedState_, , , , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(uint256(executedState_), 7);
     }
 
@@ -330,7 +330,7 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         // Alice received no ZERO rewards
         assertEq(_zeroToken.balanceOf(_alice), (1_000e6 * aliceVotingPower_) / 100);
 
-        (, , , uint256 noVotes_, uint256 yesVotes_, ) = _standardGovernor.getProposal(proposalId_);
+        (, , , uint256 noVotes_, uint256 yesVotes_, , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(yesVotes_, 0);
         assertEq(noVotes_, 0);
         assertEq(uint256(_standardGovernor.state(proposalId_)), uint256(IGovernor.ProposalState.Active));
@@ -389,7 +389,7 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         // Carol received ZERO rewards since he has 20% voting power as self-delegatee.
         assertEq(_zeroToken.balanceOf(_carol), (5_000_000e6 * 20) / 100);
 
-        (, , , noVotes_, yesVotes_, ) = _standardGovernor.getProposal(proposalId_);
+        (, , , noVotes_, yesVotes_, , ) = _standardGovernor.getProposal(proposalId_);
         assertEq(yesVotes_, bobVotingPower_);
         assertEq(noVotes_, carolVotingPower_);
         assertEq(uint256(_standardGovernor.state(proposalId_)), uint256(IGovernor.ProposalState.Active));

--- a/test/integration/zero-governor/propose/zeroGovernorPropose.t.sol
+++ b/test/integration/zero-governor/propose/zeroGovernorPropose.t.sol
@@ -40,7 +40,7 @@ contract ZeroGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_dave);
         _zeroGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState activeState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(activeState_), 1);
 
         _jumpEpochs(2);
@@ -53,7 +53,7 @@ contract ZeroGovernorPropose_IntegrationTest is IntegrationBaseSetup {
             abi.encode(0)
         );
 
-        (, , IGovernor.ProposalState expiredState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState expiredState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(expiredState_), 6);
     }
 
@@ -84,12 +84,12 @@ contract ZeroGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_dave);
         _zeroGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState activeState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(activeState_), 1);
 
         _jumpEpochs(2);
 
-        (, , IGovernor.ProposalState expiredState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState expiredState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(expiredState_), 6);
     }
 
@@ -122,7 +122,7 @@ contract ZeroGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_eve);
         _zeroGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState activeState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(activeState_), 1);
 
         uint256 eveZeroWeight_ = _zeroToken.getVotes(_eve);
@@ -132,7 +132,7 @@ contract ZeroGovernorPropose_IntegrationTest is IntegrationBaseSetup {
 
         _jumpEpochs(3);
 
-        (, , IGovernor.ProposalState defeatedState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState defeatedState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(defeatedState_), 3);
     }
 
@@ -158,10 +158,10 @@ contract ZeroGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_dave);
         assertEq(_zeroGovernor.castVote(proposalId_, yesSupport_), daveZeroWeight_);
 
-        (, , , uint256 noVotes_, uint256 yesVotes_, , uint256 thresholdRatio_) = _zeroGovernor.getProposal(proposalId_);
+        (, , , uint256 noVotes_, uint256 yesVotes_, , uint256 quorum_, ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(noVotes_, 0);
         assertEq(yesVotes_, daveZeroWeight_);
-        assertEq(thresholdRatio_, 6000);
+        assertEq(quorum_, 60_000_000e6);
 
         assertEq(uint256(_zeroGovernor.state(proposalId_)), 4); // proposal has Succeeded
 

--- a/test/integration/zero-governor/reset/reset-to-power-holders/resetToPowerHolders.t.sol
+++ b/test/integration/zero-governor/reset/reset-to-power-holders/resetToPowerHolders.t.sol
@@ -51,7 +51,7 @@ contract ResetToPowerHolders_IntegrationTest is ResetIntegrationBaseSetup {
         vm.prank(_dave);
         _zeroGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState activeState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
 
         assertEq(uint256(activeState_), 1);
 
@@ -65,7 +65,7 @@ contract ResetToPowerHolders_IntegrationTest is ResetIntegrationBaseSetup {
         vm.prank(_dave);
         assertEq(_zeroGovernor.castVote(proposalId_, yesSupport_), daveZeroWeight_);
 
-        (, , IGovernor.ProposalState succeededState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState succeededState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(succeededState_), 4);
 
         IPowerToken nextPowerToken_ = IPowerToken(IPowerTokenDeployer(_registrar.powerTokenDeployer()).nextDeploy());
@@ -102,7 +102,7 @@ contract ResetToPowerHolders_IntegrationTest is ResetIntegrationBaseSetup {
         assertEq(nextPowerToken_.balanceOf(_eve), 0);
         assertEq(nextPowerToken_.balanceOf(_frank), 0);
 
-        (, , IGovernor.ProposalState executedState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState executedState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(executedState_), 7);
 
         assertEq(IStandardGovernor(nextStandardGovernor_).cashToken(), _standardGovernor.cashToken());

--- a/test/integration/zero-governor/reset/reset-to-zero-holders/resetToZeroHolders.t.sol
+++ b/test/integration/zero-governor/reset/reset-to-zero-holders/resetToZeroHolders.t.sol
@@ -51,7 +51,7 @@ contract ResetToZeroHolders_IntegrationTest is ResetIntegrationBaseSetup {
         vm.prank(_dave);
         _zeroGovernor.propose(targets_, values_, callDatas_, description_);
 
-        (, , IGovernor.ProposalState activeState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState activeState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
 
         assertEq(uint256(activeState_), 1);
 
@@ -65,7 +65,7 @@ contract ResetToZeroHolders_IntegrationTest is ResetIntegrationBaseSetup {
         vm.prank(_dave);
         assertEq(_zeroGovernor.castVote(proposalId_, yesSupport_), daveZeroWeight_);
 
-        (, , IGovernor.ProposalState succeededState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState succeededState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(succeededState_), 4);
 
         IPowerToken nextPowerToken_ = IPowerToken(IPowerTokenDeployer(_registrar.powerTokenDeployer()).nextDeploy());
@@ -99,7 +99,7 @@ contract ResetToZeroHolders_IntegrationTest is ResetIntegrationBaseSetup {
         assertEq(nextPowerToken_.balanceOf(_eve), nextPowerToken_.pastBalanceOf(_eve, START_EPOCH));
         assertEq(nextPowerToken_.balanceOf(_frank), nextPowerToken_.pastBalanceOf(_frank, START_EPOCH));
 
-        (, , IGovernor.ProposalState executedState_, , , , ) = _zeroGovernor.getProposal(proposalId_);
+        (, , IGovernor.ProposalState executedState_, , , , , ) = _zeroGovernor.getProposal(proposalId_);
         assertEq(uint256(executedState_), 7);
 
         address[] memory powerUsers_ = new address[](3);

--- a/test/integration/zero-governor/set-thresholds/setZeroEmergencyThresholds.t.sol
+++ b/test/integration/zero-governor/set-thresholds/setZeroEmergencyThresholds.t.sol
@@ -2,48 +2,45 @@
 
 pragma solidity 0.8.23;
 
-import { IntegrationBaseSetup, IBatchGovernor, IGovernor, IZeroGovernor } from "../../IntegrationBaseSetup.t.sol";
+import { IntegrationBaseSetup, IBatchGovernor } from "../../IntegrationBaseSetup.t.sol";
 
-contract SetZeroAndEmergencyThresholds_IntegrationTest is IntegrationBaseSetup {
-    function test_zeroGovernorProposal_setZeroAndEmergencyThresholds() external {
+contract SetZeroAndEmergencyQuorums_IntegrationTest is IntegrationBaseSetup {
+    function test_zeroGovernorProposal_setZeroAndEmergencyQuorums() external {
         address[] memory targets_ = new address[](1);
         targets_[0] = address(_zeroGovernor);
 
         uint256[] memory values_ = new uint256[](1);
 
-        bytes[] memory zeroThresholdCallDatas_ = new bytes[](1);
-        zeroThresholdCallDatas_[0] = abi.encodeWithSelector(
-            _zeroGovernor.setZeroProposalThresholdRatio.selector,
-            5_000
-        );
+        bytes[] memory zeroQuorumCallDatas_ = new bytes[](1);
+        zeroQuorumCallDatas_[0] = abi.encodeWithSelector(_zeroGovernor.setZeroProposalQuorumNumerator.selector, 5_000);
 
-        bytes[] memory emergencyThresholdCallDatas_ = new bytes[](1);
-        emergencyThresholdCallDatas_[0] = abi.encodeWithSelector(
-            _zeroGovernor.setEmergencyProposalThresholdRatio.selector,
+        bytes[] memory emergencyQuorumCallDatas_ = new bytes[](1);
+        emergencyQuorumCallDatas_[0] = abi.encodeWithSelector(
+            _zeroGovernor.setEmergencyProposalQuorumNumerator.selector,
             7_000
         );
 
-        string memory zeroThresholdDescription_ = "Update zero threshold";
-        string memory emergencyThresholdDescription_ = "Update emergency threshold";
+        string memory zeroQuorumDescription_ = "Update zero quorum numerator";
+        string memory emergencyQuorumDescription_ = "Update emergency quorum numerator";
 
         _warpToNextEpoch();
 
-        // Proposal to change zero threshold
+        // Proposal to change zero quorum
         vm.prank(_dave);
         uint256 zeroProposalId_ = _zeroGovernor.propose(
             targets_,
             values_,
-            zeroThresholdCallDatas_,
-            zeroThresholdDescription_
+            zeroQuorumCallDatas_,
+            zeroQuorumDescription_
         );
 
-        // Proposal to change emergency threshold
+        // Proposal to change emergency quorum
         vm.prank(_dave);
         uint256 emergencyProposalId_ = _zeroGovernor.propose(
             targets_,
             values_,
-            emergencyThresholdCallDatas_,
-            emergencyThresholdDescription_
+            emergencyQuorumCallDatas_,
+            emergencyQuorumDescription_
         );
 
         uint8 yesSupport_ = uint8(IBatchGovernor.VoteType.Yes);
@@ -68,18 +65,18 @@ contract SetZeroAndEmergencyThresholds_IntegrationTest is IntegrationBaseSetup {
         _zeroGovernor.execute(
             targets_,
             values_,
-            emergencyThresholdCallDatas_,
-            keccak256(bytes(emergencyThresholdDescription_))
+            emergencyQuorumCallDatas_,
+            keccak256(bytes(emergencyQuorumDescription_))
         );
 
         vm.prank(_dave);
-        _zeroGovernor.execute(targets_, values_, zeroThresholdCallDatas_, keccak256(bytes(zeroThresholdDescription_)));
+        _zeroGovernor.execute(targets_, values_, zeroQuorumCallDatas_, keccak256(bytes(zeroQuorumDescription_)));
 
         assertEq(uint256(_zeroGovernor.state(zeroProposalId_)), 7); // Executed
         assertEq(uint256(_zeroGovernor.state(emergencyProposalId_)), 7); // Executed
 
-        // Aftermath of the thresholds change
-        assertEq(_emergencyGovernor.thresholdRatio(), 7_000);
-        assertEq(_zeroGovernor.thresholdRatio(), 5_000);
+        // Aftermath of the quorums change
+        assertEq(_emergencyGovernor.quorumNumerator(), 7_000);
+        assertEq(_zeroGovernor.quorumNumerator(), 5_000);
     }
 }

--- a/test/utils/BatchGovernorHarness.sol
+++ b/test/utils/BatchGovernorHarness.sol
@@ -32,8 +32,7 @@ contract BatchGovernorHarness is BatchGovernor {
         uint256 voteStart_,
         bool executed_,
         address proposer_,
-        uint256 thresholdRatio_,
-        uint256 quorumRatio_,
+        uint256 quorumNumerator_,
         uint256 noWeight_,
         uint256 yesWeight_
     ) external returns (uint256 proposalId_) {
@@ -43,8 +42,7 @@ contract BatchGovernorHarness is BatchGovernor {
             voteStart: uint16(voteStart_),
             executed: executed_,
             proposer: proposer_,
-            thresholdRatio: uint16(thresholdRatio_),
-            quorumRatio: uint16(quorumRatio_),
+            quorumNumerator: uint16(quorumNumerator_),
             noWeight: noWeight_,
             yesWeight: yesWeight_
         });
@@ -68,9 +66,11 @@ contract BatchGovernorHarness is BatchGovernor {
     |                                       External/Public View/Pure Functions                                        |
     \******************************************************************************************************************/
 
-    function quorum() external view returns (uint256) {}
+    function COUNTING_MODE() external pure returns (string memory) {
+        return "";
+    }
 
-    function quorum(uint256 timepoint_) external view returns (uint256) {}
+    function quorum() external view returns (uint256) {}
 
     function state(uint256 proposalId_) public view override returns (ProposalState) {
         return _states[proposalId_];

--- a/test/utils/EmergencyGovernorHarness.sol
+++ b/test/utils/EmergencyGovernorHarness.sol
@@ -10,8 +10,8 @@ contract EmergencyGovernorHarness is EmergencyGovernor {
         address zeroGovernor_,
         address registrar_,
         address standardGovernor_,
-        uint16 thresholdRatio_
-    ) EmergencyGovernor(voteToken_, zeroGovernor_, registrar_, standardGovernor_, thresholdRatio_) {}
+        uint256 quorumNumerator_
+    ) EmergencyGovernor(voteToken_, zeroGovernor_, registrar_, standardGovernor_, quorumNumerator_) {}
 
     function revertIfInvalidCalldata(bytes memory callData_) external pure {
         _revertIfInvalidCalldata(callData_);

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -37,10 +37,10 @@ contract MockCashToken {
 }
 
 contract MockEmergencyGovernor {
-    uint16 public thresholdRatio;
+    uint256 public quorumNumerator;
 
-    function setThresholdRatio(uint16 thresholdRatio_) external {
-        thresholdRatio = thresholdRatio_;
+    function setQuorumNumerator(uint256 quorumNumerator_) external {
+        quorumNumerator = quorumNumerator_;
     }
 }
 
@@ -56,7 +56,7 @@ contract MockEmergencyGovernorDeployer {
         nextDeploy = nextDeploy_;
     }
 
-    function deploy(address, address, uint16) external view returns (address deployed_) {
+    function deploy(address, address, uint256) external view returns (address deployed_) {
         return nextDeploy;
     }
 }

--- a/test/utils/StandardGovernorHarness.sol
+++ b/test/utils/StandardGovernorHarness.sol
@@ -61,8 +61,7 @@ contract StandardGovernorHarness is StandardGovernor {
             voteStart: uint16(voteStart_),
             executed: executed_,
             proposer: proposer_,
-            thresholdRatio: 0,
-            quorumRatio: 0,
+            quorumNumerator: 0,
             noWeight: noWeight_,
             yesWeight: yesWeight_
         });

--- a/test/utils/ZeroGovernorHarness.sol
+++ b/test/utils/ZeroGovernorHarness.sol
@@ -12,8 +12,8 @@ contract ZeroGovernorHarness is ZeroGovernor {
         address standardGovernorDeployer_,
         address bootstrapToken_,
         uint256 standardProposalFee_,
-        uint16 emergencyProposalThresholdRatio_,
-        uint16 zeroProposalThresholdRatio_,
+        uint256 emergencyProposalQuorumNumerator_,
+        uint256 zeroProposalQuorumNumerator_,
         address[] memory allowedCashTokens_
     )
         ZeroGovernor(
@@ -23,11 +23,30 @@ contract ZeroGovernorHarness is ZeroGovernor {
             standardGovernorDeployer_,
             bootstrapToken_,
             standardProposalFee_,
-            emergencyProposalThresholdRatio_,
-            zeroProposalThresholdRatio_,
+            emergencyProposalQuorumNumerator_,
+            zeroProposalQuorumNumerator_,
             allowedCashTokens_
         )
     {}
+
+    function setProposal(
+        uint256 proposalId_,
+        uint256 voteStart_,
+        bool executed_,
+        address proposer_,
+        uint256 quorumNumerator_,
+        uint256 noWeight_,
+        uint256 yesWeight_
+    ) external {
+        _proposals[proposalId_] = Proposal({
+            voteStart: uint16(voteStart_),
+            executed: executed_,
+            proposer: proposer_,
+            quorumNumerator: uint16(quorumNumerator_),
+            noWeight: noWeight_,
+            yesWeight: yesWeight_
+        });
+    }
 
     function revertIfInvalidCalldata(bytes memory callData_) external pure {
         _revertIfInvalidCalldata(callData_);


### PR DESCRIPTION
- `ONE` replaced with `quorumDenominator` for ThresholdGovernor, and isn't needed by BatchGovernor
- `quorum(uint256 timepoint)`removed as it was faulty given that quorums for past time points could change due to changes in the underlying quorum values
- "threshold ratio" has been replaced with "quorum numerator" to adhere to standards
- `getProposal` for ThresholdGovernor returns the needed quorum (i.e. threshold) instead of the ratio, since it can be easily determined and would save work for queriers
- `quorumNumerator()` and `quorumDenominator()` aded to ThresholdGovernor
- `proposalQuorum(uint256 proposalId)` aded to ThresholdGovernor to help front ends, similar to `proposalSnapshot(uint256 proposalId)`
- `quorumNumerator` inputs and output changed to a `uint256` externally to adhere to standard and simplify code
- non-standard "success" param was added to `COUNTING_MODE()` to help front ends determine success criteria -