### PR TITLE
fix(Governors): return early if zero weight

### DIFF
--- a/src/StandardGovernor.sol
+++ b/src/StandardGovernor.sol
@@ -356,8 +356,6 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
         uint8 support_,
         string memory reason_
     ) internal override {
-        if (weight_ == 0) return;
-
         ProposalState state_ = state(proposalId_);
 
         if (state_ != ProposalState.Active) revert ProposalInactive(state_);

--- a/src/StandardGovernor.sol
+++ b/src/StandardGovernor.sol
@@ -356,6 +356,8 @@ contract StandardGovernor is IStandardGovernor, BatchGovernor {
         uint8 support_,
         string memory reason_
     ) internal override {
+        if (weight_ == 0) return;
+
         ProposalState state_ = state(proposalId_);
 
         if (state_ != ProposalState.Active) revert ProposalInactive(state_);

--- a/src/abstract/BatchGovernor.sol
+++ b/src/abstract/BatchGovernor.sol
@@ -472,6 +472,7 @@ abstract contract BatchGovernor is IBatchGovernor, ERC712Extended {
         uint8 support_,
         string memory reason_
     ) internal virtual {
+        if (weight_ == 0) return;
         if (hasVoted[proposalId_][voter_]) revert AlreadyVoted();
 
         hasVoted[proposalId_][voter_] = true;

--- a/src/abstract/BatchGovernor.sol
+++ b/src/abstract/BatchGovernor.sol
@@ -472,7 +472,7 @@ abstract contract BatchGovernor is IBatchGovernor, ERC712Extended {
         uint8 support_,
         string memory reason_
     ) internal virtual {
-        if (weight_ == 0) return;
+        if (weight_ == 0) revert ZeroVotingPower();
         if (hasVoted[proposalId_][voter_]) revert AlreadyVoted();
 
         hasVoted[proposalId_][voter_] = true;

--- a/src/abstract/interfaces/IBatchGovernor.sol
+++ b/src/abstract/interfaces/IBatchGovernor.sol
@@ -80,6 +80,9 @@ interface IBatchGovernor is IGovernor {
      */
     error ProposalInactive(ProposalState state);
 
+    /// @notice Revert message when voting on a proposal with a zero voting weight.
+    error ZeroVotingPower();
+
     /* ============ Interactive Functions ============ */
 
     /**

--- a/test/BatchGovernor.t.sol
+++ b/test/BatchGovernor.t.sol
@@ -66,6 +66,8 @@ contract BatchGovernorTests is TestUtils {
 
         _voteToken.setVotePower(0);
 
+        vm.expectRevert(IBatchGovernor.ZeroVotingPower.selector);
+
         vm.prank(_alice);
         _batchGovernor.castVote(proposalId_, uint8(IBatchGovernor.VoteType.Yes));
 

--- a/test/StandardGovernor.t.sol
+++ b/test/StandardGovernor.t.sol
@@ -378,6 +378,8 @@ contract StandardGovernorTests is TestUtils {
 
         _standardGovernor.setProposal(proposalId_, currentEpoch);
 
+        vm.expectRevert(IBatchGovernor.ZeroVotingPower.selector);
+
         vm.prank(_alice);
         _standardGovernor.castVote(proposalId_, uint8(IBatchGovernor.VoteType.Yes));
 

--- a/test/StandardGovernor.t.sol
+++ b/test/StandardGovernor.t.sol
@@ -369,9 +369,27 @@ contract StandardGovernorTests is TestUtils {
         _standardGovernor.castVote(proposalId_, uint8(IBatchGovernor.VoteType.Yes));
     }
 
+    function test_castVote_zeroWeight() external {
+        uint256 proposalId_ = 1;
+        uint256 currentEpoch = _standardGovernor.clock();
+        uint256 votePower_ = 0;
+
+        _powerToken.setVotePower(votePower_);
+
+        _standardGovernor.setProposal(proposalId_, currentEpoch);
+
+        vm.prank(_alice);
+        _standardGovernor.castVote(proposalId_, uint8(IBatchGovernor.VoteType.Yes));
+
+        assertFalse(_standardGovernor.hasVoted(proposalId_, _alice));
+    }
+
     function test_castVote_alreadyVoted() external {
         uint256 proposalId_ = 1;
         uint256 currentEpoch = _standardGovernor.clock();
+
+        _powerToken.setVotePower(_votePower);
+        _powerToken.setPastTotalSupply(1);
 
         _standardGovernor.setProposal(proposalId_, currentEpoch);
         _standardGovernor.setHasVoted(proposalId_, _alice);

--- a/test/integration/standard-governor/propose/standardGovernorPropose.t.sol
+++ b/test/integration/standard-governor/propose/standardGovernorPropose.t.sol
@@ -320,7 +320,7 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         vm.prank(_alice);
         assertEq(_standardGovernor.castVote(proposalId_, uint8(IBatchGovernor.VoteType.Yes)), aliceVotingPower_);
 
-        assertTrue(_standardGovernor.hasVotedOnAllProposals(_alice, _currentEpoch()));
+        assertFalse(_standardGovernor.hasVotedOnAllProposals(_alice, _currentEpoch()));
         assertFalse(_standardGovernor.hasVotedOnAllProposals(_bob, _currentEpoch()));
         assertFalse(_standardGovernor.hasVotedOnAllProposals(_carol, _currentEpoch()));
 

--- a/test/integration/standard-governor/propose/standardGovernorPropose.t.sol
+++ b/test/integration/standard-governor/propose/standardGovernorPropose.t.sol
@@ -317,6 +317,8 @@ contract StandardGovernorPropose_IntegrationTest is IntegrationBaseSetup {
         assertEq(_powerToken.getPastVotes(_bob, proposalSnapshot_), bobVotingPower_);
         assertEq(_powerToken.getPastVotes(_carol, proposalSnapshot_), carolVotingPower_);
 
+        vm.expectRevert(IBatchGovernor.ZeroVotingPower.selector);
+
         vm.prank(_alice);
         assertEq(_standardGovernor.castVote(proposalId_, uint8(IBatchGovernor.VoteType.Yes)), aliceVotingPower_);
 

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -66,12 +66,22 @@ contract MockEpochBasedVoteToken {
 
     mapping(uint256 epoch => uint256 totalSupply) public pastTotalSupply;
 
+    uint256 internal _votePower;
+
+    function setVotePower(uint256 votePower_) external {
+        _votePower = votePower_;
+    }
+
     function setPastBalanceOf(address account_, uint256 epoch_, uint256 balance_) external {
         pastBalanceOf[account_][epoch_] = balance_;
     }
 
     function setPastTotalSupply(uint256 epoch_, uint256 totalSupplyAt_) external {
         pastTotalSupply[epoch_] = totalSupplyAt_;
+    }
+
+    function getPastVotes(address, uint256) external view returns (uint256 votePower_) {
+        return _votePower;
     }
 
     function pastBalancesOf(


### PR DESCRIPTION
Changelog

Return early in `StandardGovernor`, `BatchGovernor` and any contract inheriting from it, if vote weight of the voter is `0`.

Drawbacks

A voter voting with zero weight will not be marked has having voted despite having called the `castVote` function as outlined by the change in the integration test `standardGovernorPropose.t.sol`:
 https://github.com/MZero-Labs/ttg/compare/fix/sherlock-issue-64...fix/WEB3-895-zero-voting-weight?expand=1#diff-ad896c0eaf595c791bb6030e6cb775954f66c90ae1537930e09ad0afc8584af5R323